### PR TITLE
feat: add lev api app runner

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -28,3 +28,7 @@ provider "aws" {
 module "ecr" {
   source = "../modules/ecr"
 }
+
+module "lev_api" {
+  source = "../modules/lev_api"
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -24,3 +24,7 @@ provider "aws" {
     }
   }
 }
+
+module "lev_api" {
+  source = "../modules/lev_api"
+}

--- a/terraform/modules/lev_api/main.tf
+++ b/terraform/modules/lev_api/main.tf
@@ -1,0 +1,26 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_apprunner_service" "lev_api" {
+  service_name = "lev-api"
+
+  source_configuration {
+    image_repository {
+      image_configuration {
+        port = "8000"
+        runtime_environment_variables = {
+          LISTEN_HOST = "0.0.0.0"
+          LISTEN_PORT = "8000"
+          MOCK        = "true"
+        }
+      }
+      image_identifier      = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-2.amazonaws.com/quay/ukhomeofficedigital/lev-api:latest"
+      image_repository_type = "ECR"
+    }
+    auto_deployments_enabled = true
+  }
+
+  health_check_configuration {
+    path     = "/readiness"
+    protocol = "HTTP"
+  }
+}

--- a/terraform/modules/lev_api/outputs.tf
+++ b/terraform/modules/lev_api/outputs.tf
@@ -1,0 +1,3 @@
+output "service_url" {
+  value = aws_apprunner_service.lev_api.service_url
+}


### PR DESCRIPTION
Should pull down the lev api from quay.

By setting the "MOCK" flag we can avoid having to do much more in terms of database setup.

resolves #21 