### PR TITLE
feat: Update AppRunner configuration

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -25,10 +25,26 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "eu-west-1"
+  default_tags {
+    tags = {
+      source      = "terraform"
+      repository  = "https://github.com/alphagov/gdx-data-share-poc"
+      environment = "demo"
+    }
+  }
+}
+
 module "ecr" {
   source = "../modules/ecr"
 }
 
 module "lev_api" {
   source = "../modules/lev_api"
+  providers = {
+    aws = aws.eu-west-1
+  }
+  environment_name = "demo"
 }

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -25,6 +25,22 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "eu-west-1"
+  default_tags {
+    tags = {
+      source      = "terraform"
+      repository  = "https://github.com/alphagov/gdx-data-share-poc"
+      environment = "dev"
+    }
+  }
+}
+
 module "lev_api" {
   source = "../modules/lev_api"
+  providers = {
+    aws = aws.eu-west-1
+  }
+  environment_name = "dev"
 }

--- a/terraform/modules/ecr/ecr.tf
+++ b/terraform/modules/ecr/ecr.tf
@@ -28,7 +28,21 @@ resource "aws_ecr_registry_scanning_configuration" "ecr_scanning_configuration" 
   }
 }
 
-resource "aws_ecr_pull_through_cache_rule" "example" {
+resource "aws_ecr_pull_through_cache_rule" "quay" {
   ecr_repository_prefix = "quay"
   upstream_registry_url = "quay.io"
+}
+
+#these images are hosted and provided externally so we don't enforce scanning or immutable tags
+#tfsec:ignore:aws-ecr-enforce-immutable-repository tfsec:ignore:aws-ecr-enable-image-scans
+resource "aws_ecr_repository" "lev_api" {
+  name = "quay/ukhomeofficedigital/lev-api"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.gdx_data_share_poc_key.arn
+  }
 }

--- a/terraform/modules/lev_api/main.tf
+++ b/terraform/modules/lev_api/main.tf
@@ -1,7 +1,44 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
+resource "aws_iam_role" "lev_api_ecr_role" {
+  name = "${var.environment_name}-lev-api-ecr-role"
+
+  assume_role_policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Action : "sts:AssumeRole",
+        Principal : {
+          Service : [
+            "build.apprunner.amazonaws.com",
+          ]
+        },
+        Effect : "Allow",
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy" "apprunner_ecr_policy" {
+  name = "AWSAppRunnerServicePolicyForECRAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "lev_api_ecr_role" {
+  role       = aws_iam_role.lev_api_ecr_role.name
+  policy_arn = data.aws_iam_policy.apprunner_ecr_policy.arn
+}
+
 resource "aws_apprunner_service" "lev_api" {
-  service_name = "lev-api"
+  service_name = "${var.environment_name}-lev-api"
 
   source_configuration {
     image_repository {
@@ -15,6 +52,9 @@ resource "aws_apprunner_service" "lev_api" {
       }
       image_identifier      = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-2.amazonaws.com/quay/ukhomeofficedigital/lev-api:latest"
       image_repository_type = "ECR"
+    }
+    authentication_configuration {
+      access_role_arn = aws_iam_role.lev_api_ecr_role.arn
     }
     auto_deployments_enabled = true
   }

--- a/terraform/modules/lev_api/variables.tf
+++ b/terraform/modules/lev_api/variables.tf
@@ -1,0 +1,1 @@
+variable "environment_name" {}


### PR DESCRIPTION
- isn't abailable in eu-west-2, so this adds an eu-west-1 provider
- ensure the lev service is proxied correctly in ECR