### PR TITLE
feat: Add explicit Swagger UI Oauth redirects

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,3 +94,7 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+springdoc:
+  swagger-ui:
+    oauth2RedirectUrl: http://localhost:8080/webjars/swagger-ui/oauth2-redirect.html

--- a/terraform/modules/cognito/main.tf
+++ b/terraform/modules/cognito/main.tf
@@ -8,13 +8,14 @@ resource "aws_cognito_user_pool_domain" "domain" {
 }
 
 resource "aws_cognito_user_pool_client" "management_client" {
-  name                 = "${var.environment}-management-client"
-  user_pool_id         = aws_cognito_user_pool.pool.id
-  allowed_oauth_flows  = ["implicit"]
-  allowed_oauth_scopes = concat(aws_cognito_resource_server.data_receiver.scope_identifiers, aws_cognito_resource_server.data_retriever.scope_identifiers)
-  generate_secret      = true
-  explicit_auth_flows  = ["ADMIN_NO_SRP_AUTH"]
-  callback_urls        = [var.callback_url]
+  name                         = "${var.environment}-management-client"
+  user_pool_id                 = aws_cognito_user_pool.pool.id
+  allowed_oauth_flows          = ["implicit"]
+  allowed_oauth_scopes         = concat(aws_cognito_resource_server.data_receiver.scope_identifiers, aws_cognito_resource_server.data_retriever.scope_identifiers)
+  generate_secret              = true
+  explicit_auth_flows          = ["ADMIN_NO_SRP_AUTH"]
+  callback_urls                = [var.callback_url]
+  supported_identity_providers = ["COGNITO"]
 }
 
 resource "aws_cognito_user_pool_client" "legacy_inbound_adapter" {

--- a/terraform/modules/data-share-service/ecs.tf
+++ b/terraform/modules/data-share-service/ecs.tf
@@ -78,6 +78,8 @@ resource "aws_ecs_task_definition" "gdx_data_share_poc" {
         { "name" : "LEGACY_INBOUND_API_CLIENT_SECRET", "value" : module.cognito.legacy_inbound_client_secret },
         { "name" : "LEGACY_OUTBOUND_API_CLIENT_ID", "value" : module.cognito.legacy_outbound_client_id },
         { "name" : "LEGACY_OUTBOUND_API_CLIENT_SECRET", "value" : module.cognito.legacy_outbound_client_secret },
+
+        { "name" : "SPRINGDOC_SWAGGER_UI_OAUTH2_REDIRECT_URL", "value" : "https://${aws_cloudfront_distribution.gdx_data_share_poc.domain_name}/webjars/swagger-ui/oauth2-redirect.html" },
       ]
       logConfiguration : {
         logDriver : "awslogs",


### PR DESCRIPTION
The swagger ui auto generates a URL that has http in it, which doesn't work or make much sense, this explicitly sets the redirect url