### PR TITLE
Properly configure hmrc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This returns the event id in the message payload:
 
 ### Getting the data
 Using the retrieved event ID you can now get the full event data.  Depending on which client you use will return different data:
-- The `dwp-event-receiver` client also gets NINO data by calling a mocked HMRC API
+- The `dwp-event-receiver` client also gets NINO data by generating a programmatic NI number
 - The `hmrc-client` client only gets the death core data
 
 #### Examples for : `dwp-event-receiver`

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -21,7 +21,6 @@ services:
       - API_BASE_URL_ISSUER_URI=http://oauth2:8080/issuer1
       - API_BASE_URL_OAUTH=http://oauth2:8080/issuer1
       - API_BASE_URL_LEV=http://lev-api:8080
-      - API_BASE_URL_HMRC=https://a0519c3b-e75b-41aa-b79d-7bb41871ec62.mock.pstmn.io
       - API_BASE_URL_DATA_RECEIVER=http://gdx-data-share-poc:8080
       - SPRING_FLYWAY_URL=jdbc:postgresql://datashare-db:5432/datashare?sslmode=prefer
       - SPRING_R2DBC_URL=r2dbc:postgresql://datashare-db:5432/datashare?sslmode=prefer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - API_BASE_URL_ISSUER_URI=http://oauth2:8080/issuer1
       - API_BASE_URL_OAUTH=http://oauth2:8080/issuer1
       - API_BASE_URL_LEV=http://lev-api:8080
-      - API_BASE_URL_HMRC=https://a0519c3b-e75b-41aa-b79d-7bb41871ec62.mock.pstmn.io
       - API_BASE_URL_DATA_RECEIVER=http://gdx-data-share-poc:8080
       - SPRING_FLYWAY_URL=jdbc:postgresql://datashare-db:5432/datashare?sslmode=prefer
       - SPRING_R2DBC_URL=r2dbc:postgresql://datashare-db:5432/datashare?sslmode=prefer

--- a/src/main/kotlin/uk/gov/gdx/datashare/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/config/WebClientConfiguration.kt
@@ -18,8 +18,6 @@ import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${api.base.url.oauth}") val auth0BaseUri: String,
-  @Value("\${api.base.url.hmrc}") val hmrcApiRootUri: String,
   @Value("\${api.base.url.lev}") private val levApiRootUri: String,
   @Value("\${api.base.url.data-receiver}") private val dataReceiverUri: String,
   @Value("\${api.base.url.event-data-retrieval}") private val eventDataRetrievalUri: String
@@ -63,15 +61,6 @@ class WebClientConfiguration(
       .baseUrl(eventDataRetrievalUri)
       .clientConnector(ReactorClientHttpConnector(httpClient))
       .filter(oauth2Client)
-      .build()
-  }
-
-  @Bean
-  fun hmrcApiWebClient(): WebClient {
-    val httpClient = HttpClient.create().responseTimeout(Duration.ofMinutes(2))
-    return WebClient.builder()
-      .baseUrl(hmrcApiRootUri)
-      .clientConnector(ReactorClientHttpConnector(httpClient))
       .build()
   }
 

--- a/src/main/kotlin/uk/gov/gdx/datashare/service/EventDataRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/service/EventDataRetrievalService.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -112,8 +111,9 @@ class EventDataRetrievalService(
           eventType = event.eventType,
           eventId = eventId,
           details = event.dataPayload,
-          )
+        )
       }
+
       else -> {
         throw RuntimeException("Unknown DataSet ${event.datasetType}")
       }
@@ -126,12 +126,11 @@ class EventDataRetrievalService(
     dateOfBirth: LocalDate
   ): String? {
     log.debug("Looking up NINO from HMRC : search by {}, {}, {}", surname, forenames, dateOfBirth)
-    return hmrcApiService.findNiNoByNameAndDob(
+    return hmrcApiService.generateNiNoFromNameAndDob(
       surname = surname,
       firstname = forenames,
       dob = dateOfBirth
-    ).map { nino -> nino.ni_number }
-      .awaitSingleOrNull()
+    ).ni_number
   }
 }
 

--- a/src/main/kotlin/uk/gov/gdx/datashare/service/HmrcApiService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/service/HmrcApiService.kt
@@ -1,22 +1,17 @@
 package uk.gov.gdx.datashare.service
 
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.bodyToMono
-import reactor.core.publisher.Mono
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Service
-class HmrcApiService(
-  private val hmrcApiWebClient: WebClient
-) {
+class HmrcApiService() {
 
-  suspend fun findNiNoByNameAndDob(surname: String, firstname: String, dob: LocalDate): Mono<NinoRecord> {
-    return hmrcApiWebClient.get()
-      .uri("/hmrc/surname/$surname/firstname/$firstname/dob/$dob")
-      .retrieve()
-      .bodyToMono<NinoRecord>()
-      .onErrorResume { Mono.empty() }
+  fun generateNiNoFromNameAndDob(surname: String, firstname: String, dob: LocalDate): NinoRecord {
+    val id = (firstname + surname + dob.toString()).hashCode().toLong()
+    val niNumber = surname.substring(0, 1) + firstname.substring(0, 1) + dob.format(DateTimeFormatter.BASIC_ISO_DATE)
+      .substring(2) + surname.substring(surname.length - 1)
+    return NinoRecord(id = id, ni_number = niNumber)
   }
 }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,7 +28,6 @@ api:
       issuer-uri: http://localhost:9090/issuer1
       oauth: http://localhost:9090/issuer1
       lev: http://localhost:8099
-      hmrc: https://a0519c3b-e75b-41aa-b79d-7bb41871ec62.mock.pstmn.io
       data-receiver: http://localhost:8080
       event-data-retrieval: http://localhost:8080
     s3:

--- a/terraform/modules/data-share-service/ecs.tf
+++ b/terraform/modules/data-share-service/ecs.tf
@@ -31,7 +31,6 @@ resource "aws_ecs_task_definition" "gdx_data_share_poc" {
         { "name" : "API_BASE_URL_LEV", "value" : "https://${var.lev_url}" },
         { "name" : "API_BASE_URL_ISSUER_URI", "value" : "https://${module.cognito.issuer_domain}" },
         { "name" : "API_BASE_URL_OAUTH", "value" : "https://${module.cognito.auth_domain}" },
-        { "name" : "API_BASE_URL_HMRC", "value" : "https://a0519c3b-e75b-41aa-b79d-7bb41871ec62.mock.pstmn.io" },
         { "name" : "API_BASE_URL_DATA_RECEIVER", "value" : "http://gdx-data-share-poc:8080" },
         { "name" : "API_BASE_URL_EVENT_DATA_RETRIEVAL", "value" : "http://localhost:8080" },
         { "name" : "API_BASE_S3_INGRESS", "value" : module.ingress.name },


### PR DESCRIPTION
https://github.com/alphagov/gdx-data-share-poc/issues/72

We currently have mock value for `API_BASE_URL_HMRC`, we should figure out a better approach for this.

As we consume from an API directly, the simplest option for POC would be to stub data within the service itself, and not call out to an external endpoint, so we should

remove the config value
generate a NinoRecord programatically from `HmrcApiService`