### PR TITLE
Create metrics dashboard

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
 
   implementation("aws.sdk.kotlin:s3:0.19.0-beta")
 
+  implementation("io.micrometer:micrometer-core:1.10.2")
+  implementation("io.micrometer:micrometer-registry-cloudwatch2:1.10.2")
+
   developmentOnly("org.springframework.boot:spring-boot-devtools")
 
   testImplementation("org.awaitility:awaitility-kotlin")

--- a/src/main/kotlin/uk/gov/gdx/datashare/config/MicrometerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/config/MicrometerConfiguration.kt
@@ -1,0 +1,48 @@
+package uk.gov.gdx.datashare.config
+
+import io.micrometer.cloudwatch2.CloudWatchConfig
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry
+import io.micrometer.core.instrument.Clock
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import java.time.Duration
+
+
+@Configuration
+class MicrometerConfiguration {
+
+  @Bean
+  fun cloudWatchAsyncClient(): CloudWatchAsyncClient {
+    return CloudWatchAsyncClient
+      .builder()
+      .region(Region.EU_WEST_2)
+      .build()
+  }
+
+  @Bean
+  fun getMeterRegistry(): MeterRegistry? {
+    val cloudWatchConfig: CloudWatchConfig = setupCloudWatchConfig()
+    return CloudWatchMeterRegistry(
+      cloudWatchConfig,
+      Clock.SYSTEM,
+      cloudWatchAsyncClient()
+    )
+  }
+
+  private fun setupCloudWatchConfig(): CloudWatchConfig {
+    val cloudWatchConfig = object : CloudWatchConfig {
+      private val configuration = mapOf(
+        "cloudwatch.namespace" to "gdxApp",
+        "cloudwatch.step" to Duration.ofMinutes(1).toString()
+      )
+      override fun get(key: String): String? {
+        return configuration[key]
+      }
+    }
+    return cloudWatchConfig
+  }
+
+}

--- a/terraform/modules/data-share-service/cloudwatch.tf
+++ b/terraform/modules/data-share-service/cloudwatch.tf
@@ -11,3 +11,27 @@ resource "aws_cloudwatch_log_group" "lb_sg_update" {
 
   kms_key_id = aws_kms_key.log_key.arn
 }
+
+resource "aws_cloudwatch_dashboard" "metrics_dashboard" {
+  dashboard_name = "metrics-dashboard"
+  dashboard_body = <<EOF
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "properties": {
+        "metrics": [
+          [
+            "gdxApp",
+            "API_CALLS.IngestedEvents.count"
+          ]
+        ],
+        "period": 300,
+        "region": ${var.region},
+        "title": "API calls"
+      }
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/data-share-service/cloudwatch.tf
+++ b/terraform/modules/data-share-service/cloudwatch.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_log_group" "lb_sg_update" {
 
 resource "aws_cloudwatch_dashboard" "metrics_dashboard" {
   dashboard_name = "metrics-dashboard"
-  dashboard_body = <<EOF
+  dashboard_body = <<-EOF
 {
   "widgets": [
     {

--- a/terraform/modules/data-share-service/cloudwatch.tf
+++ b/terraform/modules/data-share-service/cloudwatch.tf
@@ -15,19 +15,19 @@ resource "aws_cloudwatch_log_group" "lb_sg_update" {
 resource "aws_cloudwatch_dashboard" "metrics_dashboard" {
   dashboard_name = "metrics-dashboard"
   dashboard_body = jsonencode({
-    "widgets": [
+    "widgets" : [
       {
-        "type": "metric",
-        "properties": {
-          "metrics": [
+        "type" : "metric",
+        "properties" : {
+          "metrics" : [
             [
               "gdxApp",
               "API_CALLS.IngestedEvents.count"
             ]
           ],
-          "period": 300,
-          "region": var.region,
-          "title": "API calls"
+          "period" : 300,
+          "region" : var.region,
+          "title" : "API calls"
         }
       }
     ]

--- a/terraform/modules/data-share-service/cloudwatch.tf
+++ b/terraform/modules/data-share-service/cloudwatch.tf
@@ -14,24 +14,23 @@ resource "aws_cloudwatch_log_group" "lb_sg_update" {
 
 resource "aws_cloudwatch_dashboard" "metrics_dashboard" {
   dashboard_name = "metrics-dashboard"
-  dashboard_body = <<-EOF
-{
-  "widgets": [
-    {
-      "type": "metric",
-      "properties": {
-        "metrics": [
-          [
-            "gdxApp",
-            "API_CALLS.IngestedEvents.count"
-          ]
-        ],
-        "period": 300,
-        "region": ${var.region},
-        "title": "API calls"
+  dashboard_body = jsonencode({
+    "widgets": [
+      {
+        "type": "metric",
+        "properties": {
+          "metrics": [
+            [
+              "gdxApp",
+              "API_CALLS.IngestedEvents.count"
+            ]
+          ],
+          "period": 300,
+          "region": var.region,
+          "title": "API calls"
+        }
       }
-    }
-  ]
-}
-EOF
+    ]
+  })
+
 }


### PR DESCRIPTION
Once the application is deployed and running, we'll want to be able to monitor things like queue throughput, availability, latency etc.

CloudWatch has enough tooling to be able to do what we need, and Spring Boot has built in metrics (through Micrometer) which can integrate with CloudWatch.

We should

configure Spring Boot to feed metrics to Cloud Watch - see [Publishing Metrics from Spring Boot to Amazon CloudWatch](https://reflectoring.io/spring-aws-cloudwatch/) for some background, we want to use Micrometer to have a minimal amount of configuration and management
set up a minimal dashboard through terraform
configure at least one metric to ensure it all feeds through - lets use /event-data-receiver for ingested events, incrementing a counter for each call to the API
Later, we'll need to consider what the most important metrics are and what we need to worry about