### PR TITLE
chore: Remove HMPPS SQS dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
   testImplementation("io.projectreactor:reactor-test")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
   testImplementation("io.mockk:mockk:1.13.3")
+  testImplementation("org.mockito:mockito-junit-jupiter:4.8.1")
+  testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
+  testImplementation("org.mockito:mockito-inline:4.8.1")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,10 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
 
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.2.0")
+  implementation(platform("com.amazonaws:aws-java-sdk-bom:1.12.337"))
+  implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.1.0")
+  implementation("com.amazonaws:aws-java-sdk-sns")
+  implementation("org.springframework:spring-jms")
   implementation("org.hibernate:hibernate-validator:8.0.0.Final")
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSnsFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSnsFactory.kt
@@ -1,0 +1,58 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder
+import com.amazonaws.services.sns.AmazonSNSClientBuilder
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class AmazonSnsFactory {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun awsSnsClient(topicId: String, accessKeyId: String, secretAccessKey: String, region: String, asyncClient: Boolean): AmazonSNS =
+    when (asyncClient) {
+      false -> awsAmazonSNS(accessKeyId, secretAccessKey, region)
+      true -> awsAmazonSNSAsync(accessKeyId, secretAccessKey, region)
+    }.also { log.info("Created an AWS SNS client for topicId=$topicId") }
+
+  fun localstackSnsClient(topicId: String, localstackUrl: String, region: String, asyncClient: Boolean): AmazonSNS =
+    when (asyncClient) {
+      false -> localstackAmazonSNS(localstackUrl, region)
+      true -> localstackAmazonSNSAsync(localstackUrl, region)
+    }.also { log.info("Created a LocalStack SNS client for topicId=$topicId") }
+
+  private fun awsAmazonSNS(accessKeyId: String, secretAccessKey: String, region: String) =
+    BasicAWSCredentials(accessKeyId, secretAccessKey)
+      .let { credentials ->
+        AmazonSNSClientBuilder.standard()
+          .withCredentials(AWSStaticCredentialsProvider(credentials))
+          .withRegion(region)
+          .build()
+      }
+
+  private fun awsAmazonSNSAsync(accessKeyId: String, secretAccessKey: String, region: String) =
+    BasicAWSCredentials(accessKeyId, secretAccessKey)
+      .let { credentials ->
+        AmazonSNSAsyncClientBuilder.standard()
+          .withCredentials(AWSStaticCredentialsProvider(credentials))
+          .withRegion(region)
+          .build()
+      }
+
+  private fun localstackAmazonSNS(localstackUrl: String, region: String) =
+    AmazonSNSClientBuilder.standard()
+      .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
+      .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials("any", "any"))) // LocalStack doesn't work with Anonymous credentials when dealing with topics but doesn't care what the credential values are.
+      .build()
+
+  private fun localstackAmazonSNSAsync(localstackUrl: String, region: String) =
+    AmazonSNSAsyncClientBuilder.standard()
+      .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
+      .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials("any", "any"))) // LocalStack doesn't work with Anonymous credentials when dealing with topics but doesn't care what the credential values are.
+      .build()
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSnsFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSnsFactory.kt
@@ -4,7 +4,6 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -14,17 +13,13 @@ class AmazonSnsFactory {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun awsSnsClient(topicId: String, accessKeyId: String, secretAccessKey: String, region: String, asyncClient: Boolean): AmazonSNS =
-    when (asyncClient) {
-      false -> awsAmazonSNS(accessKeyId, secretAccessKey, region)
-      true -> awsAmazonSNSAsync(accessKeyId, secretAccessKey, region)
-    }.also { log.info("Created an AWS SNS client for topicId=$topicId") }
+  fun awsSnsClient(topicId: String, accessKeyId: String, secretAccessKey: String, region: String): AmazonSNS =
+    awsAmazonSNS(accessKeyId, secretAccessKey, region)
+      .also { log.info("Created an AWS SNS client for topicId=$topicId") } as AmazonSNS
 
-  fun localstackSnsClient(topicId: String, localstackUrl: String, region: String, asyncClient: Boolean): AmazonSNS =
-    when (asyncClient) {
-      false -> localstackAmazonSNS(localstackUrl, region)
-      true -> localstackAmazonSNSAsync(localstackUrl, region)
-    }.also { log.info("Created a LocalStack SNS client for topicId=$topicId") }
+  fun localstackSnsClient(topicId: String, localstackUrl: String, region: String): AmazonSNS =
+    localstackAmazonSNS(localstackUrl, region)
+      .also { log.info("Created a LocalStack SNS client for topicId=$topicId") }
 
   private fun awsAmazonSNS(accessKeyId: String, secretAccessKey: String, region: String) =
     BasicAWSCredentials(accessKeyId, secretAccessKey)
@@ -35,23 +30,8 @@ class AmazonSnsFactory {
           .build()
       }
 
-  private fun awsAmazonSNSAsync(accessKeyId: String, secretAccessKey: String, region: String) =
-    BasicAWSCredentials(accessKeyId, secretAccessKey)
-      .let { credentials ->
-        AmazonSNSAsyncClientBuilder.standard()
-          .withCredentials(AWSStaticCredentialsProvider(credentials))
-          .withRegion(region)
-          .build()
-      }
-
   private fun localstackAmazonSNS(localstackUrl: String, region: String) =
     AmazonSNSClientBuilder.standard()
-      .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
-      .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials("any", "any"))) // LocalStack doesn't work with Anonymous credentials when dealing with topics but doesn't care what the credential values are.
-      .build()
-
-  private fun localstackAmazonSNSAsync(localstackUrl: String, region: String) =
-    AmazonSNSAsyncClientBuilder.standard()
       .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
       .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials("any", "any"))) // LocalStack doesn't work with Anonymous credentials when dealing with topics but doesn't care what the credential values are.
       .build()

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSqsFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSqsFactory.kt
@@ -5,7 +5,6 @@ import com.amazonaws.auth.AnonymousAWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -15,29 +14,21 @@ class AmazonSqsFactory {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun awsSqsClient(queueId: String, queueName: String, accessKeyId: String, secretAccessKey: String, region: String, asyncClient: Boolean = false): AmazonSQS =
-    when (asyncClient) {
-      false -> awsAmazonSQS(accessKeyId, secretAccessKey, region)
-      true -> awsAmazonSQSAsync(accessKeyId, secretAccessKey, region)
-    }.also { log.info("Created an AWS SQS client for queueId $queueId with name $queueName") }
+  fun awsSqsClient(queueId: String, queueName: String, accessKeyId: String, secretAccessKey: String, region: String): AmazonSQS =
+    awsAmazonSQS(accessKeyId, secretAccessKey, region)
+      .also { log.info("Created an AWS SQS client for queueId $queueId with name $queueName") }
 
-  fun localStackSqsClient(queueId: String, queueName: String, localstackUrl: String, region: String, asyncClient: Boolean = false): AmazonSQS =
-    when (asyncClient) {
-      false -> localStackAmazonSQS(localstackUrl, region)
-      true -> localStackAmazonSQSAsync(localstackUrl, region)
-    }.also { log.info("Created a LocalStack SQS client for queueId $queueId with name $queueName") }
+  fun localStackSqsClient(queueId: String, queueName: String, localstackUrl: String, region: String): AmazonSQS =
+    localStackAmazonSQS(localstackUrl, region)
+      .also { log.info("Created a LocalStack SQS client for queueId $queueId with name $queueName") }
 
-  fun awsSqsDlqClient(queueId: String, dlqName: String, accessKeyId: String, secretAccessKey: String, region: String, asyncClient: Boolean = false): AmazonSQS =
-    when (asyncClient) {
-      false -> awsAmazonSQS(accessKeyId, secretAccessKey, region)
-      true -> awsAmazonSQSAsync(accessKeyId, secretAccessKey, region)
-    }.also { log.info("Created an AWS SQS DLQ client for queueId $queueId with name $dlqName") }
+  fun awsSqsDlqClient(queueId: String, dlqName: String, accessKeyId: String, secretAccessKey: String, region: String): AmazonSQS =
+    awsAmazonSQS(accessKeyId, secretAccessKey, region)
+      .also { log.info("Created an AWS SQS DLQ client for queueId $queueId with name $dlqName") }
 
-  fun localStackSqsDlqClient(queueId: String, dlqName: String, localstackUrl: String, region: String, asyncClient: Boolean = false): AmazonSQS =
-    when (asyncClient) {
-      false -> localStackAmazonSQS(localstackUrl, region)
-      true -> localStackAmazonSQSAsync(localstackUrl, region)
-    }.also { log.info("Created a LocalStack SQS DLQ client for queueId $queueId with name $dlqName") }
+  fun localStackSqsDlqClient(queueId: String, dlqName: String, localstackUrl: String, region: String): AmazonSQS =
+    localStackAmazonSQS(localstackUrl, region)
+      .also { log.info("Created a LocalStack SQS DLQ client for queueId $queueId with name $dlqName") }
 
   private fun awsAmazonSQS(accessKeyId: String, secretAccessKey: String, region: String) =
     AmazonSQSClientBuilder.standard()
@@ -47,18 +38,6 @@ class AmazonSqsFactory {
 
   private fun localStackAmazonSQS(localstackUrl: String, region: String) =
     AmazonSQSClientBuilder.standard()
-      .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
-      .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
-      .build()
-
-  private fun awsAmazonSQSAsync(accessKeyId: String, secretAccessKey: String, region: String) =
-    AmazonSQSAsyncClientBuilder.standard()
-      .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKeyId, secretAccessKey)))
-      .withRegion(region)
-      .build()
-
-  private fun localStackAmazonSQSAsync(localstackUrl: String, region: String) =
-    AmazonSQSAsyncClientBuilder.standard()
       .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
       .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
       .build()

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSqsFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/AmazonSqsFactory.kt
@@ -1,0 +1,65 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class AmazonSqsFactory {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun awsSqsClient(queueId: String, queueName: String, accessKeyId: String, secretAccessKey: String, region: String, asyncClient: Boolean = false): AmazonSQS =
+    when (asyncClient) {
+      false -> awsAmazonSQS(accessKeyId, secretAccessKey, region)
+      true -> awsAmazonSQSAsync(accessKeyId, secretAccessKey, region)
+    }.also { log.info("Created an AWS SQS client for queueId $queueId with name $queueName") }
+
+  fun localStackSqsClient(queueId: String, queueName: String, localstackUrl: String, region: String, asyncClient: Boolean = false): AmazonSQS =
+    when (asyncClient) {
+      false -> localStackAmazonSQS(localstackUrl, region)
+      true -> localStackAmazonSQSAsync(localstackUrl, region)
+    }.also { log.info("Created a LocalStack SQS client for queueId $queueId with name $queueName") }
+
+  fun awsSqsDlqClient(queueId: String, dlqName: String, accessKeyId: String, secretAccessKey: String, region: String, asyncClient: Boolean = false): AmazonSQS =
+    when (asyncClient) {
+      false -> awsAmazonSQS(accessKeyId, secretAccessKey, region)
+      true -> awsAmazonSQSAsync(accessKeyId, secretAccessKey, region)
+    }.also { log.info("Created an AWS SQS DLQ client for queueId $queueId with name $dlqName") }
+
+  fun localStackSqsDlqClient(queueId: String, dlqName: String, localstackUrl: String, region: String, asyncClient: Boolean = false): AmazonSQS =
+    when (asyncClient) {
+      false -> localStackAmazonSQS(localstackUrl, region)
+      true -> localStackAmazonSQSAsync(localstackUrl, region)
+    }.also { log.info("Created a LocalStack SQS DLQ client for queueId $queueId with name $dlqName") }
+
+  private fun awsAmazonSQS(accessKeyId: String, secretAccessKey: String, region: String) =
+    AmazonSQSClientBuilder.standard()
+      .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKeyId, secretAccessKey)))
+      .withRegion(region)
+      .build()
+
+  private fun localStackAmazonSQS(localstackUrl: String, region: String) =
+    AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
+      .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
+      .build()
+
+  private fun awsAmazonSQSAsync(accessKeyId: String, secretAccessKey: String, region: String) =
+    AmazonSQSAsyncClientBuilder.standard()
+      .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKeyId, secretAccessKey)))
+      .withRegion(region)
+      .build()
+
+  private fun localStackAmazonSQSAsync(localstackUrl: String, region: String) =
+    AmazonSQSAsyncClientBuilder.standard()
+      .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(localstackUrl, region))
+      .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
+      .build()
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueue.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueue.kt
@@ -1,0 +1,14 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sqs.AmazonSQS
+
+class HmppsQueue(
+  val id: String,
+  val sqsClient: AmazonSQS,
+  val queueName: String,
+  val sqsDlqClient: AmazonSQS? = null,
+  val dlqName: String? = null
+) {
+  val queueUrl: String by lazy { sqsClient.getQueueUrl(queueName).queueUrl }
+  val dlqUrl by lazy { sqsDlqClient?.getQueueUrl(dlqName)?.queueUrl }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueDestinationResolver.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueDestinationResolver.kt
@@ -1,0 +1,13 @@
+package uk.gov.gdx.datashare.queue
+
+import org.springframework.jms.support.destination.DynamicDestinationResolver
+import javax.jms.Destination
+import javax.jms.Session
+
+class HmppsQueueDestinationResolver(private val hmppsSqsProperties: HmppsSqsProperties) : DynamicDestinationResolver() {
+
+  override fun resolveDestinationName(session: Session?, destinationName: String, pubSubDomain: Boolean): Destination {
+    val destination = hmppsSqsProperties.queues[destinationName]?.queueName ?: destinationName
+    return super.resolveDestinationName(session, destination, pubSubDomain)
+  }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueFactory.kt
@@ -1,0 +1,139 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazon.sqs.javamessaging.ProviderConfiguration
+import com.amazon.sqs.javamessaging.SQSConnectionFactory
+import com.amazonaws.services.sns.model.SubscribeRequest
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.QueueAttributeName
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory
+import java.lang.RuntimeException
+import javax.jms.Session
+
+class HmppsQueueFactory(
+  private val context: ConfigurableApplicationContext,
+  private val amazonSqsFactory: AmazonSqsFactory,
+) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun createHmppsQueues(hmppsSqsProperties: HmppsSqsProperties, hmppsTopics: List<HmppsTopic> = listOf()) =
+    hmppsSqsProperties.queues
+      .map { (queueId, queueConfig) ->
+        val sqsDlqClient = getOrDefaultSqsDlqClient(queueId, queueConfig, hmppsSqsProperties)
+        val sqsClient = getOrDefaultSqsClient(queueId, queueConfig, hmppsSqsProperties, sqsDlqClient)
+          .also { subscribeToLocalStackTopic(hmppsSqsProperties, queueConfig, hmppsTopics) }
+        HmppsQueue(queueId, sqsClient, queueConfig.queueName, sqsDlqClient, queueConfig.dlqName.ifEmpty { null })
+          .also { getOrDefaultHealthIndicator(it) }
+          .also { createJmsListenerContainerFactory(it, hmppsSqsProperties) }
+      }.toList()
+
+  private fun getOrDefaultSqsDlqClient(queueId: String, queueConfig: HmppsSqsProperties.QueueConfig, hmppsSqsProperties: HmppsSqsProperties): AmazonSQS? =
+    if (queueConfig.dlqName.isNotEmpty()) {
+      getOrDefaultBean("$queueId-sqs-dlq-client") {
+        createSqsDlqClient(queueId, queueConfig, hmppsSqsProperties)
+      }
+    } else null
+
+  private fun getOrDefaultSqsClient(queueId: String, queueConfig: HmppsSqsProperties.QueueConfig, hmppsSqsProperties: HmppsSqsProperties, sqsDlqClient: AmazonSQS?): AmazonSQS =
+    getOrDefaultBean("$queueId-sqs-client") {
+      createSqsClient(queueId, queueConfig, hmppsSqsProperties, sqsDlqClient)
+    }
+
+  private fun getOrDefaultHealthIndicator(hmppsQueue: HmppsQueue): HealthIndicator =
+    getOrDefaultBean("${hmppsQueue.id}-health") {
+      HmppsQueueHealth(hmppsQueue)
+    }
+
+  private fun createJmsListenerContainerFactory(hmppsQueue: HmppsQueue, hmppsSqsProperties: HmppsSqsProperties): HmppsQueueDestinationContainerFactory =
+    getOrDefaultBean("${hmppsQueue.id}-jms-listener-factory") {
+      HmppsQueueDestinationContainerFactory(hmppsQueue.id, createJmsListenerContainerFactory(hmppsQueue.sqsClient, hmppsSqsProperties))
+    }
+
+  @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+  private inline fun <reified T> getOrDefaultBean(beanName: String, createDefaultBean: () -> T) =
+    runCatching { context.beanFactory.getBean(beanName) as T }
+      .getOrElse {
+        createDefaultBean().also { bean -> context.beanFactory.registerSingleton(beanName, bean) }
+      }
+
+  fun createSqsDlqClient(queueId: String, queueConfig: HmppsSqsProperties.QueueConfig, hmppsSqsProperties: HmppsSqsProperties): AmazonSQS =
+    with(hmppsSqsProperties) {
+      if (queueConfig.dlqName.isEmpty()) throw MissingDlqNameException()
+      when (provider) {
+        "aws" -> amazonSqsFactory.awsSqsDlqClient(queueId, queueConfig.dlqName, queueConfig.dlqAccessKeyId, queueConfig.dlqSecretAccessKey, region, queueConfig.asyncDlqClient)
+        "localstack" ->
+          amazonSqsFactory.localStackSqsDlqClient(queueId, queueConfig.dlqName, localstackUrl, region, queueConfig.asyncDlqClient)
+            .also { sqsDlqClient -> sqsDlqClient.createQueue(queueConfig.dlqName) }
+        else -> throw IllegalStateException("Unrecognised HMPPS SQS provider $provider")
+      }
+    }
+
+  fun createSqsClient(queueId: String, queueConfig: HmppsSqsProperties.QueueConfig, hmppsSqsProperties: HmppsSqsProperties, sqsDlqClient: AmazonSQS?) =
+    with(hmppsSqsProperties) {
+      when (provider) {
+        "aws" -> amazonSqsFactory.awsSqsClient(queueId, queueConfig.queueName, queueConfig.queueAccessKeyId, queueConfig.queueSecretAccessKey, region, queueConfig.asyncQueueClient)
+        "localstack" ->
+          amazonSqsFactory.localStackSqsClient(queueId, queueConfig.queueName, localstackUrl, region, queueConfig.asyncQueueClient)
+            .also { sqsClient -> createLocalStackQueue(sqsClient, sqsDlqClient, queueConfig.queueName, queueConfig.dlqName, queueConfig.dlqMaxReceiveCount) }
+        else -> throw IllegalStateException("Unrecognised HMPPS SQS provider $provider")
+      }
+    }
+
+  private fun createLocalStackQueue(
+    sqsClient: AmazonSQS,
+    sqsDlqClient: AmazonSQS?,
+    queueName: String,
+    dlqName: String,
+    maxReceiveCount: Int,
+  ) {
+    if (dlqName.isEmpty() || sqsDlqClient == null) {
+      sqsClient.createQueue(CreateQueueRequest(queueName))
+    } else {
+      sqsDlqClient.getQueueUrl(dlqName).queueUrl
+        .let { dlqQueueUrl -> sqsDlqClient.getQueueAttributes(dlqQueueUrl, listOf(QueueAttributeName.QueueArn.toString())).attributes["QueueArn"] }
+        .also { queueArn ->
+          sqsClient.createQueue(
+            CreateQueueRequest(queueName).withAttributes(
+              mapOf(
+                QueueAttributeName.RedrivePolicy.toString() to
+                  """{"deadLetterTargetArn":"$queueArn","maxReceiveCount":"$maxReceiveCount"}"""
+              )
+            )
+          )
+        }
+    }
+  }
+
+  private fun subscribeToLocalStackTopic(hmppsSqsProperties: HmppsSqsProperties, queueConfig: HmppsSqsProperties.QueueConfig, hmppsTopics: List<HmppsTopic>) {
+    if (hmppsSqsProperties.provider == "localstack")
+      hmppsTopics.firstOrNull { topic -> topic.id == queueConfig.subscribeTopicId }
+        ?.also { topic ->
+          val subscribeAttribute = if (queueConfig.subscribeFilter.isNullOrEmpty()) mapOf() else mapOf("FilterPolicy" to queueConfig.subscribeFilter)
+          topic.snsClient.subscribe(
+            SubscribeRequest()
+              .withTopicArn(topic.arn)
+              .withProtocol("sqs")
+              .withEndpoint("${hmppsSqsProperties.localstackUrl}/queue/${queueConfig.queueName}")
+              .withAttributes(subscribeAttribute)
+          )
+            .also { log.info("Queue ${queueConfig.queueName} has subscribed to topic with arn ${topic.arn}") }
+        }
+  }
+
+  fun createJmsListenerContainerFactory(awsSqsClient: AmazonSQS, hmppsSqsProperties: HmppsSqsProperties): DefaultJmsListenerContainerFactory =
+    DefaultJmsListenerContainerFactory().apply {
+      setConnectionFactory(SQSConnectionFactory(ProviderConfiguration(), awsSqsClient))
+      setDestinationResolver(HmppsQueueDestinationResolver(hmppsSqsProperties))
+      setConcurrency("1-1")
+      setSessionAcknowledgeMode(Session.CLIENT_ACKNOWLEDGE)
+      setErrorHandler { t: Throwable? -> log.error("Error caught in jms listener", t) }
+    }
+}
+
+class MissingDlqNameException() : RuntimeException("Attempted to access dlq but no name has been set")

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueHealth.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueHealth.kt
@@ -1,0 +1,107 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.QueueAttributeName.All
+import com.amazonaws.services.sqs.model.QueueAttributeName.ApproximateNumberOfMessages
+import com.amazonaws.services.sqs.model.QueueAttributeName.ApproximateNumberOfMessagesNotVisible
+import com.amazonaws.services.sqs.model.QueueAttributeName.RedrivePolicy
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Health.Builder
+import org.springframework.boot.actuate.health.HealthIndicator
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
+
+class HmppsQueueHealth(private val hmppsQueue: HmppsQueue) : HealthIndicator {
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun health(): Health = buildHealth(checkQueueHealth(), checkDlqHealth())
+
+  @JvmInline
+  private value class HealthDetail(private val detail: Pair<String, String>) {
+    fun key() = detail.first
+    fun value() = detail.second
+  }
+
+  private fun checkQueueHealth(): List<Result<HealthDetail>> {
+    val results = mutableListOf<Result<HealthDetail>>()
+    results += success(HealthDetail("queueName" to hmppsQueue.queueName))
+
+    getQueueAttributes().map { attributesResult ->
+      results += success(HealthDetail("messagesOnQueue" to """${attributesResult.attributes[ApproximateNumberOfMessages.toString()]}"""))
+      results += success(HealthDetail("messagesInFlight" to """${attributesResult.attributes[ApproximateNumberOfMessagesNotVisible.toString()]}"""))
+
+      hmppsQueue.dlqName?.let {
+        attributesResult.attributes["$RedrivePolicy"] ?: run { results += failure(MissingRedrivePolicyException(hmppsQueue.id)) }
+      }
+    }.onFailure { throwable -> results += failure(throwable) }
+
+    return results.toList()
+  }
+  private fun checkDlqHealth(): List<Result<HealthDetail>> {
+    val results = mutableListOf<Result<HealthDetail>>()
+    hmppsQueue.dlqName?.run {
+      results += success(HealthDetail("dlqName" to hmppsQueue.dlqName))
+
+      hmppsQueue.sqsDlqClient?.run {
+        getDlqAttributes().map { attributesResult ->
+          results += success(
+            HealthDetail(
+              "messagesOnDlq" to
+                """${attributesResult.attributes[ApproximateNumberOfMessages.toString()]}"""
+            )
+          )
+        }.onFailure { throwable -> results += failure(throwable) }
+      }
+    }
+    return results.toList()
+  }
+
+  private fun buildHealth(queueResults: List<Result<HealthDetail>>, dlqResults: List<Result<HealthDetail>>): Health {
+    val healthBuilder = if (queueStatus(dlqResults, queueResults) == "UP") Builder().up() else Builder().down()
+    queueResults.forEach { healthBuilder.addHealthResult(it) }
+
+    if (dlqResults.isNotEmpty()) {
+      healthBuilder.withDetail("dlqStatus", dlqStatus(dlqResults, queueResults))
+      dlqResults.forEach { healthBuilder.addHealthResult(it) }
+    }
+
+    return healthBuilder.build()
+  }
+
+  private fun queueStatus(dlqResults: List<Result<HealthDetail>>, queueResults: List<Result<HealthDetail>>): String =
+    if ((queueResults + dlqResults).any { it.isFailure }) "DOWN" else "UP"
+
+  private fun dlqStatus(dlqResults: List<Result<HealthDetail>>, queueResults: List<Result<HealthDetail>>): String =
+    if (queueResults.any(::isMissingRedrivePolicy).or(dlqResults.any { it.isFailure })) "DOWN" else "UP"
+
+  private fun isMissingRedrivePolicy(result: Result<HealthDetail>) = result.exceptionOrNull() is MissingRedrivePolicyException
+
+  private fun Builder.addHealthResult(result: Result<HealthDetail>) =
+    result
+      .onSuccess { healthDetail -> withDetail(healthDetail.key(), healthDetail.value()) }
+      .onFailure { throwable ->
+        withException(throwable)
+          .also { log.error("Queue health for queueId ${hmppsQueue.id} failed due to exception", throwable) }
+      }
+
+  private fun getQueueAttributes(): Result<GetQueueAttributesResult> {
+    return runCatching {
+      hmppsQueue.sqsClient.getQueueAttributes(GetQueueAttributesRequest(hmppsQueue.queueUrl).withAttributeNames(All))
+    }
+  }
+
+  private fun getDlqAttributes(): Result<GetQueueAttributesResult> =
+    runCatching {
+      hmppsQueue.sqsDlqClient?.getQueueAttributes(GetQueueAttributesRequest(hmppsQueue.dlqUrl).withAttributeNames(All))
+        ?: throw MissingDlqClientException(hmppsQueue.dlqName)
+    }
+}
+
+class MissingRedrivePolicyException(queueId: String) : RuntimeException("The main queue for $queueId is missing a $RedrivePolicy")
+class MissingDlqClientException(dlqName: String?) : RuntimeException("Attempted to access dlqclient for $dlqName that does not exist")

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueJmsListenerContainerFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueJmsListenerContainerFactory.kt
@@ -1,0 +1,23 @@
+package uk.gov.gdx.datashare.queue
+
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory
+import org.springframework.jms.config.JmsListenerEndpoint
+import org.springframework.jms.config.MethodJmsListenerEndpoint
+import org.springframework.jms.listener.DefaultMessageListenerContainer
+
+class JmsListenerContainerFactoryMissingException(message: String) : RuntimeException(message)
+
+data class HmppsQueueDestinationContainerFactory(
+  val destination: String,
+  val factory: DefaultJmsListenerContainerFactory
+)
+
+class HmppsQueueJmsListenerContainerFactory(private val factories: List<HmppsQueueDestinationContainerFactory>) : DefaultJmsListenerContainerFactory() {
+  override fun createListenerContainer(endpoint: JmsListenerEndpoint): DefaultMessageListenerContainer {
+    return factories
+      .firstOrNull { it.destination == (endpoint as MethodJmsListenerEndpoint).destination }
+      ?.factory
+      ?.createListenerContainer(endpoint)
+      ?: throw JmsListenerContainerFactoryMissingException("Unable to find jms listener container factory for endpoint ${(endpoint as MethodJmsListenerEndpoint).destination}")
+  }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueResourceAsync.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueResourceAsync.kt
@@ -10,14 +10,9 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 
-/*
- * Warning: This is a duplicate of HmppsQueueResource but with suspend functions. Therefore, this class should be kept in sync with the non-async class.
- *
- * This class *should* just be a wrapper around HmppsQueueResource but that sometimes works and sometimes doesn't! So we're keeping the duplication for now.
- */
 @RestController
 @RequestMapping("/queue-admin")
-class HmppsQueueResourceAsync(private val hmppsQueueService: HmppsQueueService) {
+class HmppsQueueControllerAsync(private val hmppsQueueService: HmppsQueueService) {
 
   @PutMapping("/retry-dlq/{dlqName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueResourceAsync.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueResourceAsync.kt
@@ -1,0 +1,54 @@
+package uk.gov.gdx.datashare.queue
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/*
+ * Warning: This is a duplicate of HmppsQueueResource but with suspend functions. Therefore, this class should be kept in sync with the non-async class.
+ *
+ * This class *should* just be a wrapper around HmppsQueueResource but that sometimes works and sometimes doesn't! So we're keeping the duplication for now.
+ */
+@RestController
+@RequestMapping("/queue-admin")
+class HmppsQueueResourceAsync(private val hmppsQueueService: HmppsQueueService) {
+
+  @PutMapping("/retry-dlq/{dlqName}")
+  @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
+  suspend fun retryDlq(@PathVariable("dlqName") dlqName: String) =
+    hmppsQueueService.findByDlqName(dlqName)
+      ?.let { hmppsQueue -> hmppsQueueService.retryDlqMessages(RetryDlqRequest(hmppsQueue)) }
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "$dlqName not found")
+
+  /*
+   * This endpoint is not secured because it should only be called from inside the Kubernetes service.
+   * See test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/config/ResourceServerConfiguration.kt for Spring Security config.
+   * See test-app/helm_deploy/hmpps-template-kotlin/example/housekeeping-cronjob.yaml and ingress.yaml for Kubernetes config.
+   */
+  @PutMapping("/retry-all-dlqs")
+  suspend fun retryAllDlqs() = hmppsQueueService.retryAllDlqs()
+
+  @PutMapping("/purge-queue/{queueName}")
+  @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
+  suspend fun purgeQueue(@PathVariable("queueName") queueName: String) =
+    hmppsQueueService.findQueueToPurge(queueName)
+      ?.let { request -> hmppsQueueService.purgeQueue(request) }
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "$queueName not found")
+
+  /*
+    Note: Once the DLQ messages have been read, they are not visible again (for subsequent reads) for approximately 30 seconds. This is due to the visibility
+    timeout period which supports deleting of dlq messages when sent back to the processing queue
+   */
+  @GetMapping("/get-dlq-messages/{dlqName}")
+  @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
+  suspend fun getDlqMessages(@PathVariable("dlqName") dlqName: String, @RequestParam("maxMessages", required = false, defaultValue = "100") maxMessages: Int) =
+    hmppsQueueService.findByDlqName(dlqName)
+      ?.let { hmppsQueue -> hmppsQueueService.getDlqMessages(GetDlqRequest(hmppsQueue, maxMessages)) }
+      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "$dlqName not found")
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueService.kt
@@ -1,0 +1,113 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.DeleteMessageRequest
+import com.amazonaws.services.sqs.model.Message
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
+import com.amazonaws.services.sqs.model.SendMessageRequest
+import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
+import org.slf4j.LoggerFactory
+import uk.gov.gdx.datashare.queue.HmppsQueue
+import kotlin.math.min
+import com.amazonaws.services.sqs.model.PurgeQueueRequest as AwsPurgeQueueRequest
+
+class MissingQueueException(message: String) : RuntimeException(message)
+class MissingTopicException(message: String) : RuntimeException(message)
+
+open class HmppsQueueService(
+  hmppsTopicFactory: HmppsTopicFactory,
+  hmppsQueueFactory: HmppsQueueFactory,
+  hmppsSqsProperties: HmppsSqsProperties,
+) {
+
+  private companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+    private val gson = GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create()
+  }
+
+  private val hmppsTopics: List<HmppsTopic> = hmppsTopicFactory.createHmppsTopics(hmppsSqsProperties)
+  private val hmppsQueues: List<HmppsQueue> = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, hmppsTopics)
+
+  open fun findByQueueId(queueId: String) = hmppsQueues.associateBy { it.id }.getOrDefault(queueId, null)
+  open fun findByQueueName(queueName: String) = hmppsQueues.associateBy { it.queueName }.getOrDefault(queueName, null)
+  open fun findByDlqName(dlqName: String) = hmppsQueues.associateBy { it.dlqName }.getOrDefault(dlqName, null)
+
+  open fun findByTopicId(topicId: String) = hmppsTopics.associateBy { it.id }.getOrDefault(topicId, null)
+
+  open fun retryDlqMessages(request: RetryDlqRequest): RetryDlqResult =
+    request.hmppsQueue.retryDlqMessages()
+
+  open fun getDlqMessages(request: GetDlqRequest): GetDlqResult =
+    request.hmppsQueue.getDlqMessages(request.maxMessages)
+
+  open fun retryAllDlqs() =
+    hmppsQueues
+      .map { hmppsQueue -> RetryDlqRequest(hmppsQueue) }
+      .map { retryDlqRequest -> retryDlqMessages(retryDlqRequest) }
+
+  private fun HmppsQueue.retryDlqMessages(): RetryDlqResult {
+    if (sqsDlqClient == null || dlqUrl == null) return RetryDlqResult(0, mutableListOf())
+    val messageCount = sqsDlqClient.countMessagesOnQueue(dlqUrl!!)
+    val messages = mutableListOf<Message>()
+    repeat(messageCount) {
+      sqsDlqClient.receiveMessage(ReceiveMessageRequest(dlqUrl).withMaxNumberOfMessages(1).withMessageAttributeNames("All")).messages.firstOrNull()
+        ?.also { msg ->
+          sqsClient.sendMessage(SendMessageRequest().withQueueUrl(queueUrl).withMessageBody(msg.body).withMessageAttributes(msg.messageAttributes))
+          sqsDlqClient.deleteMessage(DeleteMessageRequest(dlqUrl, msg.receiptHandle))
+          messages += msg
+        }
+    }
+    messageCount.takeIf { it > 0 }
+      ?.also { log.info("For dlq ${this.dlqName} we found $messageCount messages, attempted to retry ${messages.size}") }
+    return RetryDlqResult(messageCount, messages.toList())
+  }
+
+  private fun HmppsQueue.getDlqMessages(maxMessages: Int): GetDlqResult {
+    if (sqsDlqClient == null || dlqUrl == null) return GetDlqResult(0, 0, mutableListOf())
+
+    val messages = mutableListOf<DlqMessage>()
+    val messageCount = sqsDlqClient.countMessagesOnQueue(dlqUrl!!)
+    val messagesToReturnCount = min(messageCount, maxMessages)
+
+    repeat(messagesToReturnCount) {
+      sqsDlqClient.receiveMessage(ReceiveMessageRequest(dlqUrl).withMaxNumberOfMessages(1)).messages.firstOrNull()
+        ?.also { msg ->
+          val map: Map<String, Any> = HashMap()
+          messages += DlqMessage(messageId = msg.messageId, body = gson.fromJson(msg.body, map.javaClass))
+        }
+    }
+
+    return GetDlqResult(messageCount, messagesToReturnCount, messages.toList())
+  }
+
+  open fun purgeQueue(request: PurgeQueueRequest): PurgeQueueResult =
+    with(request) {
+      sqsClient.countMessagesOnQueue(queueUrl)
+        .takeIf { it > 0 }
+        ?.also { sqsClient.purgeQueue(AwsPurgeQueueRequest(queueUrl)) }
+        ?.also { log.info("For queue $queueName attempted to purge $it messages from queue") }
+        ?.let { PurgeQueueResult(it) }
+        ?: PurgeQueueResult(0)
+    }
+
+  open fun findQueueToPurge(queueName: String): PurgeQueueRequest? =
+    findByQueueName(queueName)
+      ?.let { hmppsQueue -> PurgeQueueRequest(hmppsQueue.queueName, hmppsQueue.sqsClient, hmppsQueue.queueUrl) }
+      ?: findByDlqName(queueName)
+        ?.let { hmppsQueue -> PurgeQueueRequest(hmppsQueue.dlqName!!, hmppsQueue.sqsDlqClient!!, hmppsQueue.dlqUrl!!) }
+}
+
+data class RetryDlqRequest(val hmppsQueue: HmppsQueue)
+data class RetryDlqResult(val messagesFoundCount: Int, val messages: List<Message>)
+
+data class GetDlqRequest(val hmppsQueue: HmppsQueue, val maxMessages: Int)
+data class GetDlqResult(val messagesFoundCount: Int, val messagesReturnedCount: Int, val messages: List<DlqMessage>)
+data class DlqMessage(val body: Map<String, Any>, val messageId: String)
+
+data class PurgeQueueRequest(val queueName: String, val sqsClient: AmazonSQS, val queueUrl: String)
+data class PurgeQueueResult(val messagesFoundCount: Int)
+
+internal fun AmazonSQS.countMessagesOnQueue(queueUrl: String): Int =
+  this.getQueueAttributes(queueUrl, listOf("ApproximateNumberOfMessages"))
+    .let { it.attributes["ApproximateNumberOfMessages"]?.toInt() ?: 0 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsProperties.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsProperties.kt
@@ -17,13 +17,11 @@ data class HmppsSqsProperties(
     val queueName: String,
     val queueAccessKeyId: String = "",
     val queueSecretAccessKey: String = "",
-    val asyncQueueClient: Boolean = false,
     val subscribeTopicId: String = "",
     val subscribeFilter: String = "",
     val dlqName: String = "",
     val dlqAccessKeyId: String = "",
     val dlqSecretAccessKey: String = "",
-    val asyncDlqClient: Boolean = false,
     val dlqMaxReceiveCount: Int = 5,
   )
 
@@ -31,7 +29,6 @@ data class HmppsSqsProperties(
     val arn: String = "",
     val accessKeyId: String = "",
     val secretAccessKey: String = "",
-    val asyncClient: Boolean = false,
   ) {
     private val arnRegex = Regex("arn:aws:sns:.*:.*:(.*)$")
 

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsProperties.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsProperties.kt
@@ -11,7 +11,6 @@ data class HmppsSqsProperties(
   val localstackUrl: String = "http://localhost:4566",
   val queues: Map<String, QueueConfig> = mapOf(),
   val topics: Map<String, TopicConfig> = mapOf(),
-  val reactiveApi: Boolean = false,
 ) {
   data class QueueConfig(
     val queueName: String,

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsProperties.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsProperties.kt
@@ -1,0 +1,138 @@
+package uk.gov.gdx.datashare.queue
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "hmpps.sqs")
+data class HmppsSqsProperties(
+  val provider: String = "aws",
+  val region: String = "eu-west-2",
+  val localstackUrl: String = "http://localhost:4566",
+  val queues: Map<String, QueueConfig> = mapOf(),
+  val topics: Map<String, TopicConfig> = mapOf(),
+  val reactiveApi: Boolean = false,
+) {
+  data class QueueConfig(
+    val queueName: String,
+    val queueAccessKeyId: String = "",
+    val queueSecretAccessKey: String = "",
+    val asyncQueueClient: Boolean = false,
+    val subscribeTopicId: String = "",
+    val subscribeFilter: String = "",
+    val dlqName: String = "",
+    val dlqAccessKeyId: String = "",
+    val dlqSecretAccessKey: String = "",
+    val asyncDlqClient: Boolean = false,
+    val dlqMaxReceiveCount: Int = 5,
+  )
+
+  data class TopicConfig(
+    val arn: String = "",
+    val accessKeyId: String = "",
+    val secretAccessKey: String = "",
+    val asyncClient: Boolean = false,
+  ) {
+    private val arnRegex = Regex("arn:aws:sns:.*:.*:(.*)$")
+
+    val name: String
+      get() = if (arn.matches(arnRegex)) arnRegex.find(arn)!!.destructured.component1() else throw InvalidHmppsSqsPropertiesException("Topic ARN $arn has an invalid format")
+  }
+
+  init {
+    queues.forEach { (queueId, queueConfig) ->
+      queueIdMustBeLowerCase(queueId)
+      queueNamesMustExist(queueId, queueConfig)
+      awsQueueSecretsMustExist(queueId, queueConfig)
+      localstackTopicSubscriptionsMustExist(queueConfig, queueId)
+    }
+    topics.forEach { (topicId, topicConfig) ->
+      topicIdMustBeLowerCase(topicId)
+      awsTopicSecretsMustExist(topicId, topicConfig)
+      localstackTopicNameMustExist(topicId, topicConfig)
+    }
+    checkForAwsDuplicateValues()
+    checkForLocalStackDuplicateValues()
+  }
+
+  private fun queueIdMustBeLowerCase(queueId: String) {
+    if (queueId != queueId.lowercase()) throw InvalidHmppsSqsPropertiesException("queueId $queueId is not lowercase")
+  }
+
+  private fun queueNamesMustExist(queueId: String, queueConfig: QueueConfig) {
+    if (queueConfig.queueName.isEmpty()) throw InvalidHmppsSqsPropertiesException("queueId $queueId does not have a queue name")
+  }
+
+  private fun awsQueueSecretsMustExist(queueId: String, queueConfig: QueueConfig) {
+    if (provider == "aws") {
+      if (queueConfig.queueAccessKeyId.isEmpty()) throw InvalidHmppsSqsPropertiesException("queueId $queueId does not have a queue access key id")
+      if (queueConfig.queueSecretAccessKey.isEmpty()) throw InvalidHmppsSqsPropertiesException("queueId $queueId does not have a queue secret access key")
+      if (queueConfig.dlqName.isNotEmpty()) {
+        if (queueConfig.dlqAccessKeyId.isEmpty()) throw InvalidHmppsSqsPropertiesException("queueId $queueId does not have a DLQ access key id")
+        if (queueConfig.dlqSecretAccessKey.isEmpty()) throw InvalidHmppsSqsPropertiesException("queueId $queueId does not have a DLQ secret access key")
+      }
+    }
+  }
+
+  private fun localstackTopicSubscriptionsMustExist(
+    queueConfig: QueueConfig,
+    queueId: String
+  ) {
+    if (provider == "localstack") {
+      if (queueConfig.subscribeTopicId.isNotEmpty().and(topics.containsKey(queueConfig.subscribeTopicId).not()))
+        throw InvalidHmppsSqsPropertiesException("queueId $queueId wants to subscribe to ${queueConfig.subscribeTopicId} but it does not exist")
+    }
+  }
+
+  private fun topicIdMustBeLowerCase(topicId: String) {
+    if (topicId != topicId.lowercase()) throw InvalidHmppsSqsPropertiesException("topicId $topicId is not lowercase")
+  }
+
+  private fun localstackTopicNameMustExist(topicId: String, topicConfig: TopicConfig) {
+    if (provider == "localstack") {
+      if (topicConfig.name.isEmpty()) throw InvalidHmppsSqsPropertiesException("topicId $topicId does not have a name")
+    }
+  }
+
+  private fun awsTopicSecretsMustExist(topicId: String, topicConfig: TopicConfig) {
+    if (provider == "aws") {
+      if (topicConfig.arn.isEmpty()) throw InvalidHmppsSqsPropertiesException("topicId $topicId does not have an arn")
+      if (topicConfig.accessKeyId.isEmpty()) throw InvalidHmppsSqsPropertiesException("topicId $topicId does not have an access key id")
+      if (topicConfig.secretAccessKey.isEmpty()) throw InvalidHmppsSqsPropertiesException("topicId $topicId does not have a secret access key")
+    }
+  }
+
+  private fun checkForAwsDuplicateValues() {
+    if (provider == "aws") {
+      mustNotContainDuplicates("queue names", queues, secret = false) { it.value.queueName }
+      mustNotContainDuplicates("queue access key ids", queues) { it.value.queueAccessKeyId }
+      mustNotContainDuplicates("queue secret access keys", queues) { it.value.queueSecretAccessKey }
+
+      mustNotContainDuplicates("dlq names", queues, secret = false) { it.value.dlqName }
+      mustNotContainDuplicates("dlq access key ids", queues) { it.value.dlqAccessKeyId }
+      mustNotContainDuplicates("dlq secret access keys", queues) { it.value.dlqSecretAccessKey }
+
+      mustNotContainDuplicates("topic arns", topics, secret = false) { it.value.arn }
+      mustNotContainDuplicates("topic access key ids", topics) { it.value.accessKeyId }
+      mustNotContainDuplicates("topic secret access keys", topics) { it.value.secretAccessKey }
+    }
+  }
+
+  private fun checkForLocalStackDuplicateValues() {
+    if (provider == "localstack") {
+      mustNotContainDuplicates("queue names", queues, secret = false) { it.value.queueName }
+      mustNotContainDuplicates("dlq names", queues, secret = false) { it.value.dlqName }
+      mustNotContainDuplicates("topic names", topics, secret = false) { it.value.name }
+    }
+  }
+
+  private fun <T> mustNotContainDuplicates(description: String, source: Map<String, T>, secret: Boolean = true, valueFinder: (Map.Entry<String, T>) -> String) {
+    val duplicateValues = source.mapValues(valueFinder).values.filter { it.isNotEmpty() }.groupingBy { it }.eachCount().filterValues { it > 1 }
+    if (duplicateValues.isNotEmpty()) {
+      val outputValues = if (secret.not()) duplicateValues.keys else duplicateValues.keys.map { "${it.subSequence(0, 4)}******" }.toList()
+      throw InvalidHmppsSqsPropertiesException("Found duplicated $description: $outputValues")
+    }
+  }
+}
+
+class InvalidHmppsSqsPropertiesException(message: String) : IllegalStateException(message)

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopic.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopic.kt
@@ -1,0 +1,9 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.AmazonSNS
+
+class HmppsTopic(
+  val id: String,
+  val arn: String,
+  val snsClient: AmazonSNS,
+)

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicFactory.kt
@@ -43,10 +43,11 @@ class HmppsTopicFactory(
   fun createSnsClient(topicId: String, topicConfig: HmppsSqsProperties.TopicConfig, hmppsSqsProperties: HmppsSqsProperties) =
     with(hmppsSqsProperties) {
       when (provider) {
-        "aws" -> amazonSnsFactory.awsSnsClient(topicId, topicConfig.accessKeyId, topicConfig.secretAccessKey, region, topicConfig.asyncClient)
-        "localstack" -> amazonSnsFactory.localstackSnsClient(topicId, localstackUrl, region, topicConfig.asyncClient)
+        "aws" -> amazonSnsFactory.awsSnsClient(topicId, topicConfig.accessKeyId, topicConfig.secretAccessKey, region)
+        "localstack" -> amazonSnsFactory.localstackSnsClient(topicId, localstackUrl, region)
           .also { it.createTopic(topicConfig.name) }
           .also { log.info("Created a LocalStack SNS topic for topicId $topicId with ARN ${topicConfig.arn}") }
+
         else -> throw IllegalStateException("Unrecognised HMPPS SQS provider $provider")
       }
     }

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicFactory.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicFactory.kt
@@ -1,0 +1,53 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.AmazonSNS
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.ConfigurableApplicationContext
+
+class HmppsTopicFactory(
+  private val context: ConfigurableApplicationContext,
+  private val amazonSnsFactory: AmazonSnsFactory,
+) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun createHmppsTopics(hmppsSqsProperties: HmppsSqsProperties) =
+    hmppsSqsProperties.topics
+      .map { (topicId, topicConfig) ->
+        val snsClient = getOrDefaultSnsClient(topicId, topicConfig, hmppsSqsProperties)
+        HmppsTopic(topicId, topicConfig.arn, snsClient)
+          .also { getOrDefaultHealthIndicator(it) }
+      }.toList()
+
+  private fun getOrDefaultHealthIndicator(topic: HmppsTopic) {
+    "${topic.id}-health".let { beanName ->
+      runCatching { context.beanFactory.getBean(beanName) as AmazonSNS }
+        .getOrElse {
+          HmppsTopicHealth(topic)
+            .also { context.beanFactory.registerSingleton(beanName, it) }
+        }
+    }
+  }
+
+  private fun getOrDefaultSnsClient(topicId: String, topicConfig: HmppsSqsProperties.TopicConfig, hmppsSqsProperties: HmppsSqsProperties): AmazonSNS =
+    "$topicId-sns-client".let { beanName ->
+      runCatching { context.beanFactory.getBean(beanName) as AmazonSNS }
+        .getOrElse {
+          createSnsClient(topicId, topicConfig, hmppsSqsProperties)
+            .also { context.beanFactory.registerSingleton(beanName, it) }
+        }
+    }
+
+  fun createSnsClient(topicId: String, topicConfig: HmppsSqsProperties.TopicConfig, hmppsSqsProperties: HmppsSqsProperties) =
+    with(hmppsSqsProperties) {
+      when (provider) {
+        "aws" -> amazonSnsFactory.awsSnsClient(topicId, topicConfig.accessKeyId, topicConfig.secretAccessKey, region, topicConfig.asyncClient)
+        "localstack" -> amazonSnsFactory.localstackSnsClient(topicId, localstackUrl, region, topicConfig.asyncClient)
+          .also { it.createTopic(topicConfig.name) }
+          .also { log.info("Created a LocalStack SNS topic for topicId $topicId with ARN ${topicConfig.arn}") }
+        else -> throw IllegalStateException("Unrecognised HMPPS SQS provider $provider")
+      }
+    }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicHealth.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicHealth.kt
@@ -1,0 +1,32 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.model.GetTopicAttributesResult
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Health.Builder
+import org.springframework.boot.actuate.health.HealthIndicator
+
+class HmppsTopicHealth(private val hmppsTopic: HmppsTopic) : HealthIndicator {
+
+  override fun health(): Health {
+    val healthBuilder = Builder().up()
+
+    healthBuilder.withDetail("topicArn", hmppsTopic.arn)
+
+    getTopicAttributes()
+      .onSuccess { result ->
+        healthBuilder.withDetail("subscriptionsConfirmed", """${result.attributes["SubscriptionsConfirmed"]}""")
+        healthBuilder.withDetail("subscriptionsPending", """${result.attributes["SubscriptionsPending"]}""")
+      }
+      .onFailure { throwable ->
+        healthBuilder.down().withException(throwable)
+      }
+
+    return healthBuilder.build()
+  }
+
+  private fun getTopicAttributes(): Result<GetTopicAttributesResult> {
+    return runCatching {
+      hmppsTopic.snsClient.getTopicAttributes(hmppsTopic.arn)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/QueueConfig.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/QueueConfig.kt
@@ -1,0 +1,44 @@
+package uk.gov.gdx.datashare.queue
+
+import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
+import org.springframework.jms.annotation.EnableJms
+
+@Configuration
+@EnableConfigurationProperties(HmppsSqsProperties::class)
+@EnableJms
+@AutoConfigureBefore(HealthEndpointAutoConfiguration::class)
+class HmppsSqsConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun hmppsTopicFactory(applicationContext: ConfigurableApplicationContext) = HmppsTopicFactory(applicationContext, AmazonSnsFactory())
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun hmppsQueueFactory(applicationContext: ConfigurableApplicationContext) = HmppsQueueFactory(applicationContext, AmazonSqsFactory())
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun hmppsQueueService(
+    hmppsTopicFactory: HmppsTopicFactory,
+    hmppsQueueFactory: HmppsQueueFactory,
+    hmppsSqsProperties: HmppsSqsProperties,
+  ) = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun hmppsQueueResourceAsync(hmppsQueueService: HmppsQueueService) = HmppsQueueResourceAsync(hmppsQueueService)
+
+  @Bean
+  @ConditionalOnMissingBean
+  @DependsOn("hmppsQueueService")
+  fun hmppsQueueContainerFactoryProxy(factories: List<HmppsQueueDestinationContainerFactory>) = HmppsQueueJmsListenerContainerFactory(factories)
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/queue/QueueConfig.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/queue/QueueConfig.kt
@@ -35,7 +35,7 @@ class HmppsSqsConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  fun hmppsQueueResourceAsync(hmppsQueueService: HmppsQueueService) = HmppsQueueResourceAsync(hmppsQueueService)
+  fun hmppsQueueControllerAsync(hmppsQueueService: HmppsQueueService) = HmppsQueueControllerAsync(hmppsQueueService)
 
   @Bean
   @ConditionalOnMissingBean

--- a/src/main/kotlin/uk/gov/gdx/datashare/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/service/AuditService.kt
@@ -6,8 +6,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import uk.gov.justice.hmpps.sqs.HmppsQueue
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.gdx.datashare.queue.HmppsQueue
+import uk.gov.gdx.datashare.queue.HmppsQueueService
 import java.time.Instant
 import java.util.*
 

--- a/src/main/kotlin/uk/gov/gdx/datashare/service/DataReceiverService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/service/DataReceiverService.kt
@@ -10,8 +10,8 @@ import uk.gov.gdx.datashare.config.AuthenticationFacade
 import uk.gov.gdx.datashare.config.DateTimeHandler
 import uk.gov.gdx.datashare.controller.EventToPublish
 import uk.gov.gdx.datashare.repository.*
-import uk.gov.justice.hmpps.sqs.HmppsQueue
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.gdx.datashare.queue.HmppsQueue
+import uk.gov.gdx.datashare.queue.HmppsQueueService
 import java.time.LocalDateTime
 import java.util.*
 

--- a/src/main/kotlin/uk/gov/gdx/datashare/service/DataShareTopicService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/service/DataShareTopicService.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.gdx.datashare.queue.HmppsQueueService
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -1,5 +1,4 @@
 hmpps.sqs:
-  reactiveApi: true
   provider: localstack
   queues:
     dataprocessor:

--- a/src/test/kotlin/uk/gov/gdx/datashare/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/integration/SqsIntegrationTestBase.kt
@@ -10,11 +10,12 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import uk.gov.gdx.datashare.integration.LocalStackContainer.setLocalStackProperties
-import uk.gov.justice.hmpps.sqs.HmppsQueue
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
-import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
-import uk.gov.justice.hmpps.sqs.MissingQueueException
-import uk.gov.justice.hmpps.sqs.MissingTopicException
+import uk.gov.gdx.datashare.queue.HmppsQueue
+import uk.gov.gdx.datashare.queue.HmppsQueueService
+import uk.gov.gdx.datashare.queue.HmppsSqsProperties
+import uk.gov.gdx.datashare.queue.MissingQueueException
+import uk.gov.gdx.datashare.queue.MissingTopicException
+
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")

--- a/src/test/kotlin/uk/gov/gdx/datashare/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/integration/SqsIntegrationTestBase.kt
@@ -10,12 +10,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import uk.gov.gdx.datashare.integration.LocalStackContainer.setLocalStackProperties
-import uk.gov.gdx.datashare.queue.HmppsQueue
-import uk.gov.gdx.datashare.queue.HmppsQueueService
-import uk.gov.gdx.datashare.queue.HmppsSqsProperties
-import uk.gov.gdx.datashare.queue.MissingQueueException
-import uk.gov.gdx.datashare.queue.MissingTopicException
-
+import uk.gov.gdx.datashare.queue.*
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -30,7 +25,9 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   @Autowired
   protected lateinit var objectMapper: ObjectMapper
 
-  private val eventTopic by lazy { hmppsQueueService.findByTopicId("event") ?: throw MissingQueueException("Topic event not found") }
+  private val eventTopic by lazy {
+    hmppsQueueService.findByTopicId("event") ?: throw MissingQueueException("Topic event not found")
+  }
   protected val eventTopicSnsClient by lazy { eventTopic.snsClient }
   protected val eventTopicArn by lazy { eventTopic.arn }
 
@@ -64,7 +61,8 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   protected fun jsonString(any: Any) = objectMapper.writeValueAsString(any) as String
 
   fun getNumberOfMessagesCurrentlyOnAdaptorQueue(): Int? {
-    val queueAttributes = adaptorQueue.sqsClient.getQueueAttributes(adaptorQueue.queueUrl, listOf("ApproximateNumberOfMessages"))
+    val queueAttributes =
+      adaptorQueue.sqsClient.getQueueAttributes(adaptorQueue.queueUrl, listOf("ApproximateNumberOfMessages"))
     return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
   }
 }

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsNoDlqQueueFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsNoDlqQueueFactoryTest.kt
@@ -1,0 +1,325 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.contains
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.ConfigurableApplicationContext
+
+class HmppsNoDlqQueueFactoryTest {
+
+  private val localstackArnPrefix = "arn:aws:sns:eu-west-2:000000000000:"
+
+  private val context = mock<ConfigurableApplicationContext>()
+  private val beanFactory = mock<ConfigurableListableBeanFactory>()
+  private val sqsFactory = mock<AmazonSqsFactory>()
+  private val hmppsQueueFactory = HmppsQueueFactory(context, sqsFactory)
+
+  init {
+    whenever(context.beanFactory).thenReturn(beanFactory)
+  }
+
+  @Nested
+  inner class `Create single AWS HmppsQueue with no dlq` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      queueName = "some queue name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `creates aws sqs client but does not create aws sqs dlq client from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2")
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return the queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should return the queue name`() {
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should return the queue url`() {
+      assertThat(hmppsQueues[0].queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `should not return dlq client`() {
+      assertThat(hmppsQueues[0].sqsDlqClient).isNull()
+    }
+
+    @Test
+    fun `should not return dlq name`() {
+      assertThat(hmppsQueues[0].dlqName).isNull()
+    }
+
+    @Test
+    fun `should not return dlq url`() {
+      assertThat(hmppsQueues[0].dlqUrl).isNull()
+    }
+
+    @Test
+    fun `should register a health indicator`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+    }
+
+    @Test
+    fun `should register the sqs client but not the dlq client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-client", sqsClient)
+      verify(beanFactory, never()).registerSingleton(contains("dlq-client"), any<AmazonSQS>())
+    }
+
+    @Test
+    fun `should register the jms listener factory`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-jms-listener-factory"), any<HmppsQueueDestinationContainerFactory>())
+    }
+  }
+
+  @Nested
+  inner class `Create single LocalStack HmppsQueue with no dlq` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(queueName = "some queue name")
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `creates LocalStack sqs client from sqs factory but not dlq client`() {
+      verify(sqsFactory).localStackSqsClient(queueId = "somequeueid", localstackUrl = "http://localhost:4566", region = "eu-west-2", queueName = "some queue name")
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return the queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should return the queue name`() {
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should return the queue url`() {
+      assertThat(hmppsQueues[0].queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `should not return a dlq client`() {
+      assertThat(hmppsQueues[0].sqsDlqClient).isNull()
+    }
+
+    @Test
+    fun `should not return a dlq name`() {
+      assertThat(hmppsQueues[0].dlqName).isNull()
+    }
+
+    @Test
+    fun `should not return a dlq url`() {
+      assertThat(hmppsQueues[0].dlqUrl).isNull()
+    }
+
+    @Test
+    fun `should register a health indicator`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+    }
+
+    @Test
+    fun `should register the sqs client but not the dlq client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-client", sqsClient)
+      verify(beanFactory, never()).registerSingleton(contains("dlq-client"), any<AmazonSQS>())
+    }
+
+    @Test
+    fun `should create a queue without a redrive policy`() {
+      verify(sqsClient).createQueue(
+        check<CreateQueueRequest> {
+          assertThat(it.attributes).doesNotContainEntry("RedrivePolicy", """{"deadLetterTargetArn":"some dlq arn","maxReceiveCount":"5"}""")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class `Create multiple AWS HmppsQueues without dlqs` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      queueName = "some queue name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key"
+    )
+    private val anotherQueueConfig = HmppsSqsProperties.QueueConfig(
+      queueName = "another queue name",
+      queueAccessKeyId = "another access key id",
+      queueSecretAccessKey = "another secret access key"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig, "anotherqueueid" to anotherQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl("some queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsClient.getQueueUrl("another queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("another queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create multiple sqs clients but no dlq clients from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2")
+      verify(sqsFactory).awsSqsClient("anotherqueueid", "another queue name", "another access key id", "another secret access key", "eu-west-2")
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return multiple queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+      assertThat(hmppsQueues[1].id).isEqualTo("anotherqueueid")
+    }
+
+    @Test
+    fun `should register multiple health indicators`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+      verify(beanFactory).registerSingleton(eq("anotherqueueid-health"), any<HmppsQueueHealth>())
+    }
+  }
+
+  @Nested
+  inner class `Create LocalStack HmppsQueue with topic subscription` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      subscribeTopicId = "sometopicid",
+      subscribeFilter = "some topic filter",
+      queueName = "some-queue-name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key"
+    )
+    private val someTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "${localstackArnPrefix}some-topic-name",
+      accessKeyId = "topic access key",
+      secretAccessKey = "topic secret"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig), topics = mapOf("sometopicid" to someTopicConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val snsClient = mock<AmazonSNS>()
+    private val topics = listOf(HmppsTopic(id = "sometopicid", arn = "some topic arn", snsClient = snsClient))
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should subscribe to the topic`() {
+      verify(snsClient).subscribe(
+        check { subscribeRequest ->
+          assertThat(subscribeRequest.topicArn).isEqualTo("some topic arn")
+          assertThat(subscribeRequest.protocol).isEqualTo("sqs")
+          assertThat(subscribeRequest.endpoint).isEqualTo("http://localhost:4566/queue/some-queue-name")
+          assertThat(subscribeRequest.attributes["FilterPolicy"]).isEqualTo("some topic filter")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class `Create AWS HmppsQueue with topic subscription` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      subscribeTopicId = "sometopicid",
+      subscribeFilter = "some topic filter",
+      queueName = "some queue name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key"
+    )
+    private val someTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "some topic arn",
+      accessKeyId = "topic access key",
+      secretAccessKey = "topic secret"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig), topics = mapOf("sometopicid" to someTopicConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val snsClient = mock<AmazonSNS>()
+    private val topics = listOf(HmppsTopic(id = "sometopicid", arn = "some topic arn", snsClient = snsClient))
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should not subscribe to the topic`() {
+      verifyNoMoreInteractions(snsClient)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsNoDlqQueueHealthTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsNoDlqQueueHealthTest.kt
@@ -1,0 +1,150 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import com.amazonaws.services.sqs.model.QueueAttributeName
+import com.amazonaws.services.sqs.model.QueueDoesNotExistException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.actuate.health.Status
+
+class HmppsNoDlqQueueHealthTest {
+
+  private val sqsClient = mock<AmazonSQS>()
+  private val queueId = "some queue id"
+  private val queueUrl = "some queue url"
+  private val queueName = "some queue"
+  private val messagesOnQueueCount = 123
+  private val messagesInFlightCount = 456
+  private val queueHealth = HmppsQueueHealth(HmppsQueue(queueId, sqsClient, queueName))
+
+  @Test
+  fun `should show status UP`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.UP)
+  }
+
+  @Test
+  fun `should include queue name`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["queueName"]).isEqualTo(queueName)
+  }
+
+  @Test
+  fun `should include interesting attributes`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["messagesOnQueue"]).isEqualTo("$messagesOnQueueCount")
+    assertThat(health.details["messagesInFlight"]).isEqualTo("$messagesInFlightCount")
+  }
+
+  @Test
+  fun `should show status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should show exception causing status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["error"] as String).contains("Exception")
+  }
+
+  @Test
+  fun `should show queue name if status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["queueName"]).isEqualTo(queueName)
+  }
+
+  @Test
+  fun `should show status DOWN if unable to retrieve queue attributes`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenThrow(RuntimeException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should not show DLQ name`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqName"]).isNull()
+  }
+
+  @Test
+  fun `should not show interesting DLQ attributes`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["messagesOnDlq"]).isNull()
+  }
+
+  @Test
+  fun `should not show DLQ name if no dlq exists`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqName"]).isNull()
+  }
+
+  @Test
+  fun `should not show DLQ status if no dlq exists`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqStatus"]).isNull()
+  }
+
+  private fun mockHealthyQueue() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+  }
+
+  private fun someGetQueueAttributesRequest() =
+    GetQueueAttributesRequest(queueUrl).withAttributeNames(listOf(QueueAttributeName.All.toString()))
+
+  private fun someGetQueueUrlResult(): GetQueueUrlResult = GetQueueUrlResult().withQueueUrl(queueUrl)
+  private fun someGetQueueAttributesResultWithoutDLQ() = GetQueueAttributesResult().withAttributes(
+    mapOf(
+      "ApproximateNumberOfMessages" to "$messagesOnQueueCount",
+      "ApproximateNumberOfMessagesNotVisible" to "$messagesInFlightCount"
+    )
+  )
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueFactoryTest.kt
@@ -1,0 +1,383 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.ConfigurableApplicationContext
+
+class HmppsQueueFactoryTest {
+
+  private val localstackArnPrefix = "arn:aws:sns:eu-west-2:000000000000:"
+
+  private val context = mock<ConfigurableApplicationContext>()
+  private val beanFactory = mock<ConfigurableListableBeanFactory>()
+  private val sqsFactory = mock<AmazonSqsFactory>()
+  private val hmppsQueueFactory = HmppsQueueFactory(context, sqsFactory)
+
+  init {
+    whenever(context.beanFactory).thenReturn(beanFactory)
+  }
+
+  @Nested
+  inner class `Create single AWS HmppsQueue` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      queueName = "some queue name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key",
+      dlqName = "some dlq name",
+      dlqAccessKeyId = "dlq access key id",
+      dlqSecretAccessKey = "dlq secret access key"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsDlqClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsDlqClient)
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsDlqClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `creates aws sqs dlq client from sqs factory`() {
+      verify(sqsFactory).awsSqsDlqClient("somequeueid", "some dlq name", "dlq access key id", "dlq secret access key", "eu-west-2")
+    }
+
+    @Test
+    fun `creates aws sqs client from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2")
+    }
+
+    @Test
+    fun `should return the queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should return the queue name`() {
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should return the queue url`() {
+      assertThat(hmppsQueues[0].queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `should return the dlq client`() {
+      assertThat(hmppsQueues[0].sqsDlqClient).isEqualTo(sqsDlqClient)
+    }
+
+    @Test
+    fun `should return the dlq name`() {
+      assertThat(hmppsQueues[0].dlqName).isEqualTo("some dlq name")
+    }
+
+    @Test
+    fun `should return the dlq url`() {
+      assertThat(hmppsQueues[0].dlqUrl).isEqualTo("some dlq url")
+    }
+
+    @Test
+    fun `should register a health indicator`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+    }
+
+    @Test
+    fun `should register the sqs client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-client", sqsClient)
+    }
+
+    @Test
+    fun `should register the sqs dlq client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-dlq-client", sqsDlqClient)
+    }
+
+    @Test
+    fun `should register the jms listener factory`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-jms-listener-factory"), any<HmppsQueueDestinationContainerFactory>())
+    }
+  }
+
+  @Nested
+  inner class `Create single LocalStack HmppsQueue` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(queueName = "some queue name", dlqName = "some dlq name")
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsDlqClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsDlqClient)
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsDlqClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(sqsDlqClient.getQueueAttributes(anyString(), anyList())).thenReturn(GetQueueAttributesResult().withAttributes(mapOf("QueueArn" to "some dlq arn")))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `creates LocalStack sqs dlq client from sqs factory`() {
+      verify(sqsFactory).localStackSqsDlqClient(queueId = "somequeueid", localstackUrl = "http://localhost:4566", region = "eu-west-2", dlqName = "some dlq name")
+    }
+
+    @Test
+    fun `creates LocalStack sqs client from sqs factory`() {
+      verify(sqsFactory).localStackSqsClient(queueId = "somequeueid", localstackUrl = "http://localhost:4566", region = "eu-west-2", queueName = "some queue name")
+    }
+
+    @Test
+    fun `should return the queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should return the queue name`() {
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should return the queue url`() {
+      assertThat(hmppsQueues[0].queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `should return the dlq client`() {
+      assertThat(hmppsQueues[0].sqsDlqClient).isEqualTo(sqsDlqClient)
+    }
+
+    @Test
+    fun `should return the dlq name`() {
+      assertThat(hmppsQueues[0].dlqName).isEqualTo("some dlq name")
+    }
+
+    @Test
+    fun `should return the dlq url`() {
+      assertThat(hmppsQueues[0].dlqUrl).isEqualTo("some dlq url")
+    }
+
+    @Test
+    fun `should register a health indicator`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+    }
+
+    @Test
+    fun `should register the sqs client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-client", sqsClient)
+    }
+
+    @Test
+    fun `should register the sqs dlq client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-dlq-client", sqsDlqClient)
+    }
+
+    @Test
+    fun `should retrieve the dlq arn from the dlq client`() {
+      verify(sqsDlqClient).getQueueAttributes("some dlq url", listOf("QueueArn"))
+    }
+
+    @Test
+    fun `should create a queue with a redrive policy`() {
+      verify(sqsClient).createQueue(
+        check<CreateQueueRequest> {
+          assertThat(it.attributes).containsEntry("RedrivePolicy", """{"deadLetterTargetArn":"some dlq arn","maxReceiveCount":"5"}""")
+        }
+      )
+    }
+
+    @Test
+    fun `should use configurable maxReceiveCount on RedrivePolicy`() {
+      val someQueueConfig =
+        HmppsSqsProperties.QueueConfig(queueName = "some queue name", dlqName = "some dlq name", dlqMaxReceiveCount = 2)
+      val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig))
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+
+      verify(sqsClient).createQueue(
+        check<CreateQueueRequest> {
+          assertThat(it.attributes).containsEntry("RedrivePolicy", """{"deadLetterTargetArn":"some dlq arn","maxReceiveCount":"2"}""")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class `Create multiple AWS HmppsQueues` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      queueName = "some queue name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key",
+      dlqName = "some dlq name",
+      dlqAccessKeyId = "dlq access key id",
+      dlqSecretAccessKey = "dlq secret access key"
+    )
+    private val anotherQueueConfig = HmppsSqsProperties.QueueConfig(queueName = "another queue name", queueAccessKeyId = "another access key id", queueSecretAccessKey = "another secret access key", dlqName = "another dlq name", dlqAccessKeyId = "another dlq access key id", dlqSecretAccessKey = "another dlq secret access key")
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig, "anotherqueueid" to anotherQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsDlqClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsDlqClient)
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl("some queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsDlqClient.getQueueUrl("some dlq name")).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(sqsClient.getQueueUrl("another queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("another queue url"))
+      whenever(sqsDlqClient.getQueueUrl("another dlq name")).thenReturn(GetQueueUrlResult().withQueueUrl("another dlq url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create multiple dlq clients from sqs factory`() {
+      verify(sqsFactory).awsSqsDlqClient("somequeueid", "some dlq name", "dlq access key id", "dlq secret access key", "eu-west-2")
+      verify(sqsFactory).awsSqsDlqClient("anotherqueueid", "another dlq name", "another dlq access key id", "another dlq secret access key", "eu-west-2")
+    }
+
+    @Test
+    fun `should create multiple sqs clients from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2")
+      verify(sqsFactory).awsSqsClient("anotherqueueid", "another queue name", "another access key id", "another secret access key", "eu-west-2")
+    }
+
+    @Test
+    fun `should return multiple queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+      assertThat(hmppsQueues[1].id).isEqualTo("anotherqueueid")
+    }
+
+    @Test
+    fun `should register multiple health indicators`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+      verify(beanFactory).registerSingleton(eq("anotherqueueid-health"), any<HmppsQueueHealth>())
+    }
+  }
+
+  @Nested
+  inner class `Create LocalStack HmppsQueue with topic subscription` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(
+      subscribeTopicId = "sometopicid",
+      subscribeFilter = "some topic filter",
+      queueName = "some-queue-name",
+      queueAccessKeyId = "some access key id",
+      queueSecretAccessKey = "some secret access key",
+      dlqName = "some dlq name",
+      dlqAccessKeyId = "dlq access key id",
+      dlqSecretAccessKey = "dlq secret access key"
+    )
+    private val someTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "${localstackArnPrefix}some-topic-name",
+      accessKeyId = "topic access key",
+      secretAccessKey = "topic secret"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig), topics = mapOf("sometopicid" to someTopicConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+    private val snsClient = mock<AmazonSNS>()
+    private val topics = listOf(HmppsTopic(id = "sometopicid", arn = "some topic arn", snsClient = snsClient))
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsDlqClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsDlqClient)
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsDlqClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(sqsDlqClient.getQueueAttributes(anyString(), anyList())).thenReturn(GetQueueAttributesResult().withAttributes(mapOf("QueueArn" to "some dlq arn")))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should subscribe to the topic`() {
+      verify(snsClient).subscribe(
+        check { subscribeRequest ->
+          assertThat(subscribeRequest.topicArn).isEqualTo("some topic arn")
+          assertThat(subscribeRequest.protocol).isEqualTo("sqs")
+          assertThat(subscribeRequest.endpoint).isEqualTo("http://localhost:4566/queue/some-queue-name")
+          assertThat(subscribeRequest.attributes["FilterPolicy"]).isEqualTo("some topic filter")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class `Create AWS HmppsQueue with topic subscription` {
+    private val someQueueConfig = HmppsSqsProperties.QueueConfig(subscribeTopicId = "sometopicid", subscribeFilter = "some topic filter", queueName = "some queue name", queueAccessKeyId = "some access key id", queueSecretAccessKey = "some secret access key", dlqName = "some dlq name", dlqAccessKeyId = "dlq access key id", dlqSecretAccessKey = "dlq secret access key")
+    private val someTopicConfig = HmppsSqsProperties.TopicConfig(arn = "some topic arn", accessKeyId = "topic access key", secretAccessKey = "topic secret")
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig), topics = mapOf("sometopicid" to someTopicConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+    private val snsClient = mock<AmazonSNS>()
+    private val topics = listOf(HmppsTopic(id = "sometopicid", arn = "some topic arn", snsClient = snsClient))
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsDlqClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsDlqClient)
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(sqsClient)
+      whenever(sqsDlqClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should not subscribe to the topic`() {
+      verifyNoMoreInteractions(snsClient)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueHealthTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueHealthTest.kt
@@ -1,0 +1,236 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import com.amazonaws.services.sqs.model.QueueAttributeName
+import com.amazonaws.services.sqs.model.QueueDoesNotExistException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.actuate.health.Status
+
+class HmppsQueueHealthTest {
+
+  private val sqsClient = mock<AmazonSQS>()
+  private val sqsDlqClient = mock<AmazonSQS>()
+  private val queueId = "some queue id"
+  private val queueUrl = "some queue url"
+  private val dlqUrl = "some dlq url"
+  private val queueName = "some queue"
+  private val dlqName = "some dlq"
+  private val messagesOnQueueCount = 123
+  private val messagesInFlightCount = 456
+  private val messagesOnDLQCount = 789
+  private val queueHealth = HmppsQueueHealth(HmppsQueue(queueId, sqsClient, queueName, sqsDlqClient, dlqName))
+
+  @Test
+  fun `should show status UP`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.UP)
+  }
+
+  @Test
+  fun `should include queue name`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["queueName"]).isEqualTo(queueName)
+  }
+
+  @Test
+  fun `should include interesting attributes`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["messagesOnQueue"]).isEqualTo("$messagesOnQueueCount")
+    assertThat(health.details["messagesInFlight"]).isEqualTo("$messagesInFlightCount")
+  }
+
+  @Test
+  fun `should show status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should show exception causing status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["error"] as String).contains("Exception")
+  }
+
+  @Test
+  fun `should show queue name if status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["queueName"]).isEqualTo(queueName)
+  }
+
+  @Test
+  fun `should show status DOWN if unable to retrieve queue attributes`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenThrow(RuntimeException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should show DLQ status UP`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqStatus"]).isEqualTo("UP")
+  }
+
+  @Test
+  fun `should show DLQ name`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqName"]).isEqualTo(dlqName)
+  }
+
+  @Test
+  fun `should show interesting DLQ attributes`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["messagesOnDlq"]).isEqualTo("$messagesOnDLQCount")
+  }
+
+  @Test
+  fun `should show status DOWN if DLQ status is down`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+    assertThat(health.details["dlqStatus"]).isEqualTo("DOWN")
+  }
+
+  @Test
+  fun `should show DLQ name if DLQ status is down`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqName"]).isEqualTo(dlqName)
+  }
+
+  @Test
+  fun `should show DLQ status DOWN if no RedrivePolicy attribute on main queue`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqStatus"]).isEqualTo("DOWN")
+  }
+
+  @Test
+  fun `should show DLQ status DOWN if DLQ not found`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithDLQ()
+    )
+    whenever(sqsDlqClient.getQueueUrl(dlqName)).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqStatus"]).isEqualTo("DOWN")
+  }
+
+  @Test
+  fun `should show exception causing DLQ status DOWN`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithDLQ()
+    )
+    whenever(sqsDlqClient.getQueueUrl(dlqName)).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["error"] as String).contains("Exception")
+  }
+
+  @Test
+  fun `should show DLQ status DOWN if unable to retrieve DLQ attributes`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithDLQ()
+    )
+    whenever(sqsDlqClient.getQueueUrl(dlqName)).thenReturn(someGetQueueUrlResultForDLQ())
+    whenever(sqsDlqClient.getQueueAttributes(someGetQueueAttributesRequestForDLQ())).thenThrow(RuntimeException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqStatus"]).isEqualTo("DOWN")
+  }
+
+  private fun mockHealthyQueue() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithDLQ()
+    )
+    whenever(sqsDlqClient.getQueueUrl(dlqName)).thenReturn(someGetQueueUrlResultForDLQ())
+    whenever(sqsDlqClient.getQueueAttributes(someGetQueueAttributesRequestForDLQ())).thenReturn(
+      someGetQueueAttributesResultForDLQ()
+    )
+  }
+
+  private fun someGetQueueAttributesRequest() =
+    GetQueueAttributesRequest(queueUrl).withAttributeNames(listOf(QueueAttributeName.All.toString()))
+
+  private fun someGetQueueUrlResult(): GetQueueUrlResult = GetQueueUrlResult().withQueueUrl(queueUrl)
+  private fun someGetQueueAttributesResultWithoutDLQ() = GetQueueAttributesResult().withAttributes(
+    mapOf(
+      "ApproximateNumberOfMessages" to "$messagesOnQueueCount",
+      "ApproximateNumberOfMessagesNotVisible" to "$messagesInFlightCount"
+    )
+  )
+
+  private fun someGetQueueAttributesResultWithDLQ() = GetQueueAttributesResult().withAttributes(
+    mapOf(
+      "ApproximateNumberOfMessages" to "$messagesOnQueueCount",
+      "ApproximateNumberOfMessagesNotVisible" to "$messagesInFlightCount",
+      QueueAttributeName.RedrivePolicy.toString() to "any redrive policy"
+    )
+  )
+
+  private fun someGetQueueAttributesRequestForDLQ() =
+    GetQueueAttributesRequest(dlqUrl).withAttributeNames(listOf(QueueAttributeName.All.toString()))
+
+  private fun someGetQueueUrlResultForDLQ(): GetQueueUrlResult = GetQueueUrlResult().withQueueUrl(dlqUrl)
+  private fun someGetQueueAttributesResultForDLQ() = GetQueueAttributesResult().withAttributes(
+    mapOf("ApproximateNumberOfMessages" to messagesOnDLQCount.toString())
+  )
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsQueueServiceTest.kt
@@ -1,0 +1,616 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple.tuple
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.*
+import com.amazonaws.services.sqs.model.PurgeQueueRequest as AwsPurgeQueueRequest
+
+class HmppsQueueServiceTest {
+
+  private val hmppsTopicFactory = mock<HmppsTopicFactory>()
+  private val hmppsQueueFactory = mock<HmppsQueueFactory>()
+  private val hmppsSqsProperties = mock<HmppsSqsProperties>()
+  private lateinit var hmppsQueueService: HmppsQueueService
+
+  @Nested
+  inner class HmppsQueues {
+
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+
+    @BeforeEach
+    fun `add test data`() {
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsDlqClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(hmppsQueueFactory.createHmppsQueues(any(), any()))
+        .thenReturn(
+          listOf(
+            HmppsQueue("some queue id", sqsClient, "some queue name", sqsDlqClient, "some dlq name"),
+            HmppsQueue("another queue id", mock(), "another queue name", mock(), "another dlq name"),
+          )
+        )
+
+      hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+    }
+
+    @Test
+    fun `finds an hmpps queue by queue id`() {
+      assertThat(hmppsQueueService.findByQueueId("some queue id")?.queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `finds an hmpps queue by queue name`() {
+      assertThat(hmppsQueueService.findByQueueName("some queue name")?.queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `finds an hmpps queue by dlq name`() {
+      assertThat(hmppsQueueService.findByDlqName("some dlq name")?.dlqUrl).isEqualTo("some dlq url")
+    }
+
+    @Test
+    fun `returns null if queue id not found`() {
+      assertThat(hmppsQueueService.findByQueueId("unknown")).isNull()
+    }
+
+    @Test
+    fun `returns null if queue not found`() {
+      assertThat(hmppsQueueService.findByQueueName("unknown")).isNull()
+    }
+
+    @Test
+    fun `returns null if dlq not found`() {
+      assertThat(hmppsQueueService.findByDlqName("unknown")).isNull()
+    }
+  }
+
+  @Nested
+  inner class RetryDlqMessages {
+
+    private val dlqSqs = mock<AmazonSQS>()
+    private val queueSqs = mock<AmazonSQS>()
+
+    @BeforeEach
+    fun `stub getting of queue url`() {
+      whenever(queueSqs.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("queueUrl"))
+      whenever(dlqSqs.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("dlqUrl"))
+
+      hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+    }
+
+    @Nested
+    inner class NoMessages {
+      @BeforeEach
+      fun `finds zero messages on dlq`() {
+        whenever(dlqSqs.getQueueAttributes(anyString(), eq(listOf("ApproximateNumberOfMessages")))).thenReturn(
+          GetQueueAttributesResult().withAttributes(mapOf("ApproximateNumberOfMessages" to "0"))
+        )
+      }
+
+      @Test
+      fun `should not attempt any transfer`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(dlqSqs).getQueueAttributes("dlqUrl", listOf("ApproximateNumberOfMessages"))
+        verify(dlqSqs, times(0)).receiveMessage(any<ReceiveMessageRequest>())
+      }
+
+      @Test
+      fun `should return empty result`() {
+        val result =
+          hmppsQueueService.retryDlqMessages(
+            RetryDlqRequest(
+              HmppsQueue(
+                "some queue id",
+                queueSqs,
+                "some queue name",
+                dlqSqs,
+                "some dlq name"
+              )
+            )
+          )
+
+        assertThat(result.messagesFoundCount).isEqualTo(0)
+        assertThat(result.messages).isEmpty()
+      }
+    }
+
+    @Nested
+    inner class SingleMessage {
+      @BeforeEach
+      fun `finds a single message on the dlq`() {
+        whenever(dlqSqs.getQueueAttributes(anyString(), eq(listOf("ApproximateNumberOfMessages")))).thenReturn(
+          GetQueueAttributesResult().withAttributes(mapOf("ApproximateNumberOfMessages" to "1"))
+        )
+        whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+          .thenReturn(
+            ReceiveMessageResult().withMessages(
+              Message()
+                .withBody("message-body")
+                .withReceiptHandle("message-receipt-handle")
+                .withMessageAttributes(mutableMapOf("some" to stringAttributeOf("attribute")))
+            )
+          )
+
+        hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+      }
+
+      @Test
+      fun `should receive message from the dlq`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(dlqSqs).receiveMessage(
+          check<ReceiveMessageRequest> {
+            assertThat(it.queueUrl).isEqualTo("dlqUrl")
+            assertThat(it.maxNumberOfMessages).isEqualTo(1)
+          }
+        )
+      }
+
+      @Test
+      fun `should delete message from the dlq`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(dlqSqs).deleteMessage(
+          check {
+            assertThat(it.queueUrl).isEqualTo("dlqUrl")
+            assertThat(it.receiptHandle).isEqualTo("message-receipt-handle")
+          }
+        )
+      }
+
+      @Test
+      fun `should send message to the main queue`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+        verify(queueSqs).sendMessage(
+          SendMessageRequest().withQueueUrl("queueUrl").withMessageBody("message-body")
+            .withMessageAttributes(mutableMapOf("some" to stringAttributeOf("attribute")))
+        )
+      }
+
+      @Test
+      fun `should return the message`() {
+        val result = hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        assertThat(result.messagesFoundCount).isEqualTo(1)
+        assertThat(result.messages)
+          .extracting(Message::getBody, Message::getReceiptHandle)
+          .containsExactly(tuple("message-body", "message-receipt-handle"))
+      }
+    }
+
+    @Nested
+    inner class MultipleMessages {
+      @BeforeEach
+      fun `finds two message on the dlq`() {
+        whenever(dlqSqs.getQueueAttributes(anyString(), eq(listOf("ApproximateNumberOfMessages")))).thenReturn(
+          GetQueueAttributesResult().withAttributes(mapOf("ApproximateNumberOfMessages" to "2"))
+        )
+        whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+          .thenReturn(
+            ReceiveMessageResult().withMessages(
+              Message()
+                .withBody("message-1-body")
+                .withReceiptHandle("message-1-receipt-handle")
+                .withMessageAttributes((mutableMapOf("attribute-key-1" to stringAttributeOf("attribute-value-1"))))
+            )
+          )
+          .thenReturn(
+            ReceiveMessageResult().withMessages(
+              Message()
+                .withBody("message-2-body")
+                .withReceiptHandle("message-2-receipt-handle")
+                .withMessageAttributes((mutableMapOf("attribute-key-2" to stringAttributeOf("attribute-value-2"))))
+            )
+          )
+
+        hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+      }
+
+      @Test
+      fun `should receive message from the dlq`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(dlqSqs, times(2)).receiveMessage(
+          check<ReceiveMessageRequest> {
+            assertThat(it.queueUrl).isEqualTo("dlqUrl")
+            assertThat(it.maxNumberOfMessages).isEqualTo(1)
+          }
+        )
+      }
+
+      @Test
+      fun `should delete message from the dlq`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        val captor = argumentCaptor<DeleteMessageRequest>()
+        verify(dlqSqs, times(2)).deleteMessage(captor.capture())
+
+        assertThat(captor.firstValue.receiptHandle).isEqualTo("message-1-receipt-handle")
+        assertThat(captor.secondValue.receiptHandle).isEqualTo("message-2-receipt-handle")
+      }
+
+      @Test
+      fun `should send message to the main queue`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(queueSqs).sendMessage(
+          SendMessageRequest().withQueueUrl("queueUrl").withMessageBody("message-1-body")
+            .withMessageAttributes((mutableMapOf("attribute-key-1" to stringAttributeOf("attribute-value-1"))))
+        )
+        verify(queueSqs).sendMessage(
+          SendMessageRequest().withQueueUrl("queueUrl").withMessageBody("message-2-body")
+            .withMessageAttributes((mutableMapOf("attribute-key-2" to stringAttributeOf("attribute-value-2"))))
+        )
+      }
+
+      @Test
+      fun `should return the message`() {
+        val result = hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        assertThat(result.messagesFoundCount).isEqualTo(2)
+        assertThat(result.messages)
+          .extracting(Message::getBody, Message::getReceiptHandle)
+          .containsExactly(
+            tuple("message-1-body", "message-1-receipt-handle"),
+            tuple("message-2-body", "message-2-receipt-handle")
+          )
+      }
+    }
+
+    @Nested
+    inner class MultipleMessagesSomeNotFound {
+      @BeforeEach
+      fun `finds only one of two message on the dlq`() {
+        whenever(dlqSqs.getQueueAttributes(anyString(), eq(listOf("ApproximateNumberOfMessages")))).thenReturn(
+          GetQueueAttributesResult().withAttributes(mapOf("ApproximateNumberOfMessages" to "2"))
+        )
+        whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+          .thenReturn(
+            ReceiveMessageResult().withMessages(
+              Message().withBody("message-1-body").withReceiptHandle("message-1-receipt-handle")
+                .withMessageAttributes(mutableMapOf("some" to stringAttributeOf("attribute")))
+            )
+          )
+          .thenReturn(ReceiveMessageResult())
+
+        hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+      }
+
+      @Test
+      fun `should receive message from the dlq`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(dlqSqs, times(2)).receiveMessage(
+          check<ReceiveMessageRequest> {
+            assertThat(it.queueUrl).isEqualTo("dlqUrl")
+            assertThat(it.maxNumberOfMessages).isEqualTo(1)
+          }
+        )
+      }
+
+      @Test
+      fun `should delete message from the dlq`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(dlqSqs).deleteMessage(
+          check {
+            assertThat(it.queueUrl).isEqualTo("dlqUrl")
+            assertThat(it.receiptHandle).isEqualTo("message-1-receipt-handle")
+          }
+        )
+      }
+
+      @Test
+      fun `should send message to the main queue`() {
+        hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        verify(queueSqs).sendMessage(
+          SendMessageRequest().withQueueUrl("queueUrl").withMessageBody("message-1-body")
+            .withMessageAttributes(mutableMapOf("some" to stringAttributeOf("attribute")))
+        )
+      }
+
+      @Test
+      fun `should return the message`() {
+        val result = hmppsQueueService.retryDlqMessages(
+          RetryDlqRequest(
+            HmppsQueue(
+              "some queue id",
+              queueSqs,
+              "some queue name",
+              dlqSqs,
+              "some dlq name"
+            )
+          )
+        )
+
+        assertThat(result.messagesFoundCount).isEqualTo(2)
+        assertThat(result.messages)
+          .extracting(Message::getBody, Message::getReceiptHandle)
+          .containsExactly(tuple("message-1-body", "message-1-receipt-handle"))
+      }
+    }
+  }
+
+  @Nested
+  inner class GetDlqMessages {
+    private val dlqSqs = mock<AmazonSQS>()
+    private val queueSqs = mock<AmazonSQS>()
+
+    @BeforeEach
+    fun `stub getting of queue url`() {
+      whenever(queueSqs.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("queueUrl"))
+      whenever(dlqSqs.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("dlqUrl"))
+
+      hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+    }
+
+    @BeforeEach
+    fun `gets a message on the dlq`() {
+      whenever(dlqSqs.getQueueAttributes(anyString(), eq(listOf("ApproximateNumberOfMessages")))).thenReturn(
+        GetQueueAttributesResult().withAttributes(mapOf("ApproximateNumberOfMessages" to "1"))
+      )
+      whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+        .thenReturn(
+          ReceiveMessageResult().withMessages(
+            Message().withBody(
+              """{
+                                            "Message":{
+                                                "id":"event-id",
+                                                "contents":"event-contents",
+                                                "longProperty":12345678
+                                            },
+                                            "MessageId":"message-id-1"
+                                          }"""
+            )
+              .withReceiptHandle("message-1-receipt-handle").withMessageId("external-message-id-1")
+          )
+        )
+
+      hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should get messages from the dlq`() {
+      val dlqResult = hmppsQueueService.getDlqMessages(
+        GetDlqRequest(
+          HmppsQueue(
+            "some queue id",
+            queueSqs,
+            "some queue name",
+            dlqSqs,
+            "some dlq name"
+          ), 10
+        )
+      )
+      assertThat(dlqResult.messagesFoundCount).isEqualTo(1)
+      assertThat(dlqResult.messagesReturnedCount).isEqualTo(1)
+      assertThat(dlqResult.messages).hasSize(1)
+      assertThat(dlqResult.messages[0].messageId).isEqualTo("external-message-id-1")
+      val messageMap = dlqResult.messages[0].body["Message"] as Map<*, *>
+      assertThat(messageMap["longProperty"]).isEqualTo(12345678L)
+      verify(dlqSqs).receiveMessage(
+        check<ReceiveMessageRequest> {
+          assertThat(it.queueUrl).isEqualTo("dlqUrl")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class FindQueueToPurge {
+
+    private val sqsClient = mock<AmazonSQS>()
+    private val sqsDlqClient = mock<AmazonSQS>()
+
+    @BeforeEach
+    fun `add test data`() {
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsDlqClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some dlq url"))
+      whenever(hmppsQueueFactory.createHmppsQueues(any(), any()))
+        .thenReturn(
+          listOf(
+            HmppsQueue("some queue id", sqsClient, "some queue name", sqsDlqClient, "some dlq name"),
+            HmppsQueue("another queue id", mock(), "another queue name", mock(), "another dlq name"),
+          )
+        )
+
+      hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should find the main queue`() {
+      val request = hmppsQueueService.findQueueToPurge("some queue name")
+
+      assertThat(request?.queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should find the dlq`() {
+      val request = hmppsQueueService.findQueueToPurge("some dlq name")
+
+      assertThat(request?.queueName).isEqualTo("some dlq name")
+    }
+
+    @Test
+    fun `should return null if not queue or dlq`() {
+      val request = hmppsQueueService.findQueueToPurge("unknown queue name")
+
+      assertThat(request).isNull()
+    }
+  }
+
+  @Nested
+  inner class PurgeQueue {
+
+    private val sqsClient = mock<AmazonSQS>()
+    private val hmppsQueueService = HmppsQueueService(hmppsTopicFactory, hmppsQueueFactory, hmppsSqsProperties)
+
+    @Test
+    fun `no messages found, should not attempt to purge queue`() {
+      stubMessagesOnQueue(0)
+
+      hmppsQueueService.purgeQueue(PurgeQueueRequest("some queue", sqsClient, "some queue url"))
+
+      verify(sqsClient, times(0)).purgeQueue(any())
+    }
+
+    @Test
+    fun `messages found, should attempt to purge queue`() {
+      stubMessagesOnQueue(1)
+
+      hmppsQueueService.purgeQueue(PurgeQueueRequest("some queue", sqsClient, "some queue url"))
+
+      verify(sqsClient).purgeQueue(AwsPurgeQueueRequest("some queue url"))
+    }
+
+    @Test
+    fun `should return number of messages found to purge`() {
+      stubMessagesOnQueue(5)
+
+      val result = hmppsQueueService.purgeQueue(PurgeQueueRequest("some queue", sqsClient, "some queue url"))
+
+      assertThat(result.messagesFoundCount).isEqualTo(5)
+    }
+
+    private fun stubMessagesOnQueue(messageCount: Int) {
+      whenever(sqsClient.getQueueUrl(anyString()))
+        .thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsClient.getQueueAttributes(anyString(), eq(listOf("ApproximateNumberOfMessages"))))
+        .thenReturn(GetQueueAttributesResult().withAttributes(mapOf("ApproximateNumberOfMessages" to "$messageCount")))
+    }
+  }
+}
+
+private fun stringAttributeOf(value: String?): MessageAttributeValue? {
+  return MessageAttributeValue()
+    .withDataType("String")
+    .withStringValue(value)
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsPropertiesTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsSqsPropertiesTest.kt
@@ -1,0 +1,446 @@
+package uk.gov.gdx.datashare.queue
+
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class HmppsSqsPropertiesTest {
+
+  private val localstackArnPrefix = "arn:aws:sns:eu-west-2:000000000000:"
+
+  @Nested
+  inner class GeneralRules {
+
+    @Test
+    fun `should not allow lowercase queueId`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(queues = mapOf("notLowerCaseQueueId" to validAwsQueueConfig()))
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("notLowerCaseQueueId")
+        .hasMessageContaining("lowercase")
+    }
+
+    @Test
+    fun `should not allow lowercase topicId`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf("queueid" to validAwsQueueConfig()),
+          topics = mapOf("notLowerCaseTopicId" to validAwsTopicConfig())
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("notLowerCaseTopicId")
+        .hasMessageContaining("lowercase")
+    }
+
+    @Test
+    fun `should retrieve name for localstack topic`() {
+      val properties = HmppsSqsProperties(
+        provider = "localstack",
+        queues = mapOf("queueid" to validLocalstackQueueConfig()),
+        topics = mapOf("topicid" to validLocalstackTopicConfig().copy(arn = "${localstackArnPrefix}topic-name"))
+      )
+
+      assertThat(properties.topics["topicid"]?.name).isEqualTo("topic-name")
+    }
+  }
+
+  @Nested
+  inner class AwsMandatoryProperties {
+    @Test
+    fun `should require a queue access key ID`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueConfig().copy(queueAccessKeyId = "")))
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("queueid")
+        .hasMessageContaining("queue access key id")
+    }
+
+    @Test
+    fun `should require a queue secret access key`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueConfig().copy(queueSecretAccessKey = "")))
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("queueid")
+        .hasMessageContaining("queue secret access key")
+    }
+
+    @Test
+    fun `should require a dlq access key ID`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueConfig().copy(dlqAccessKeyId = "")))
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("queueid")
+        .hasMessageContaining("DLQ access key id")
+    }
+
+    @Test
+    fun `should not require a dlq access key ID if no dlq exists`() {
+      assertThatNoException().isThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueNoDlqConfig().copy(dlqAccessKeyId = "")))
+      }
+    }
+
+    @Test
+    fun `should require a dlq secret access key`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueConfig().copy(dlqSecretAccessKey = "")))
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("queueid")
+        .hasMessageContaining("DLQ secret access key")
+    }
+
+    @Test
+    fun `should not require a dlq secret access key if no dlq exists`() {
+      assertThatNoException().isThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueNoDlqConfig().copy(dlqSecretAccessKey = "")))
+      }
+    }
+
+    @Test
+    fun `topics should have an arn`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf("queueid" to validAwsQueueConfig()),
+          topics = mapOf("topicid" to validAwsTopicConfig().copy(arn = ""))
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("topicid")
+        .hasMessageContaining("arn")
+    }
+
+    @Test
+    fun `topics should have an access key id`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf("queueid" to validAwsQueueConfig()),
+          topics = mapOf("topicid" to validAwsTopicConfig().copy(accessKeyId = ""))
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("topicid")
+        .hasMessageContaining("access key id")
+    }
+
+    @Test
+    fun `topics should have a secret access key`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf("queueid" to validAwsQueueConfig()),
+          topics = mapOf("topicid" to validAwsTopicConfig().copy(secretAccessKey = ""))
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("topicid")
+        .hasMessageContaining("secret access key")
+    }
+  }
+
+  @Nested
+  inner class LocalStackMandatoryProperties {
+
+    @Test
+    fun `topic name should exist`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf("queueid" to validLocalstackQueueConfig()),
+          topics = mapOf("topicid" to validLocalstackTopicConfig().copy(arn = localstackArnPrefix))
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("topicid")
+        .hasMessageContaining("name")
+    }
+
+    @Test
+    fun `topic should exist if subscribing to it`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf("queueid" to validLocalstackQueueConfig().copy(subscribeTopicId = "topicid"))
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("queueid")
+        .hasMessageContaining("topicid")
+        .hasMessageContaining("does not exist")
+    }
+  }
+
+  @Nested
+  inner class AwsDuplicateValues {
+
+    @Test
+    fun `queue names should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(
+            "queueid1" to validAwsQueueConfig(1).copy(queueName = "1stQueueName"),
+            "queueid2" to validAwsQueueConfig(2).copy(queueName = "2ndQueueName"),
+            "queueid3" to validAwsQueueConfig(3).copy(queueName = "1stQueueName")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated queue name")
+        .hasMessageContaining("1stQueueName")
+        .hasMessageNotContaining("2ndQueueName")
+    }
+
+    @Test
+    fun `access key ids should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(
+            "queueid1" to validAwsQueueConfig(1).copy(queueAccessKeyId = "1stAccessKey"),
+            "queueid2" to validAwsQueueConfig(2).copy(queueAccessKeyId = "2ndAccessKey"),
+            "queueid3" to validAwsQueueConfig(3).copy(queueAccessKeyId = "1stAccessKey"),
+            "queueid4" to validAwsQueueConfig(4).copy(queueAccessKeyId = "2ndAccessKey"),
+            "queueid5" to validAwsQueueConfig(5).copy(queueAccessKeyId = "3rdAccessKey")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated queue access key id")
+        .hasMessageContaining("1stA******")
+        .hasMessageContaining("2ndA******")
+        .hasMessageNotContaining("3rdA******")
+    }
+
+    @Test
+    fun `queue secret access keys should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(
+            "queueid1" to validAwsQueueConfig(1).copy(queueSecretAccessKey = "1stSecretKey"),
+            "queueid2" to validAwsQueueConfig(2).copy(queueSecretAccessKey = "1stSecretKey"),
+            "queueid3" to validAwsQueueConfig(3).copy(queueSecretAccessKey = "2ndSecretKey")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated queue secret access keys")
+        .hasMessageContaining("1stS******")
+        .hasMessageNotContaining("2ndS******")
+    }
+
+    @Test
+    fun `dlq names should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(
+            "queueid1" to validAwsQueueConfig(1).copy(dlqName = "1stDlqName"),
+            "queueid2" to validAwsQueueConfig(2).copy(dlqName = "2ndDlqName"),
+            "queueid3" to validAwsQueueConfig(3).copy(dlqName = "2ndDlqName")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated dlq name")
+        .hasMessageContaining("2ndDlqName")
+        .hasMessageNotContaining("1stDlqName")
+    }
+
+    @Test
+    fun `dlq access key ids should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(
+            "queueid1" to validAwsQueueConfig(1).copy(dlqAccessKeyId = "1stAccessKey"),
+            "queueid2" to validAwsQueueConfig(2).copy(dlqAccessKeyId = "2ndAccessKey"),
+            "queueid3" to validAwsQueueConfig(3).copy(dlqAccessKeyId = "1stAccessKey"),
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated dlq access key id")
+        .hasMessageContaining("1stA******")
+        .hasMessageNotContaining("2ndA******")
+    }
+
+    @Test
+    fun `dlq secret access keys should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(
+            "queueid1" to validAwsQueueConfig(1).copy(dlqSecretAccessKey = "1stSecretKey"),
+            "queueid2" to validAwsQueueConfig(2).copy(dlqSecretAccessKey = "1stSecretKey"),
+            "queueid3" to validAwsQueueConfig(3).copy(dlqSecretAccessKey = "2ndSecretKey")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated dlq secret access keys")
+        .hasMessageContaining("1stS******")
+        .hasMessageNotContaining("2ndS******")
+    }
+
+    @Test
+    fun `topic arns should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(),
+          topics = mapOf(
+            "topic1" to validAwsTopicConfig(1).copy(arn = "1stArn"),
+            "topic2" to validAwsTopicConfig(2).copy(arn = "2ndArn"),
+            "topic3" to validAwsTopicConfig(3).copy(arn = "1stArn")
+          )
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated topic arns")
+        .hasMessageContaining("1stArn")
+        .hasMessageNotContaining("2ndArn")
+    }
+
+    @Test
+    fun `topic access key ids should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(),
+          topics = mapOf(
+            "topic1" to validAwsTopicConfig(1).copy(accessKeyId = "1stAccessKey"),
+            "topic2" to validAwsTopicConfig(2).copy(accessKeyId = "2ndAccessKey"),
+            "topic3" to validAwsTopicConfig(3).copy(accessKeyId = "1stAccessKey")
+          )
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated topic access key ids")
+        .hasMessageContaining("1stA******")
+        .hasMessageNotContaining("2ndA******")
+    }
+
+    @Test
+    fun `topic secret access keys should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          queues = mapOf(),
+          topics = mapOf(
+            "topic1" to validAwsTopicConfig(1).copy(secretAccessKey = "1stSecretKey"),
+            "topic2" to validAwsTopicConfig(2).copy(secretAccessKey = "2ndSecretKey"),
+            "topic3" to validAwsTopicConfig(3).copy(secretAccessKey = "1stSecretKey")
+          )
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated topic secret access keys")
+        .hasMessageContaining("1stS******")
+        .hasMessageNotContaining("2ndS******")
+    }
+  }
+
+  @Nested
+  inner class LocalStackDuplicateValues {
+
+    @Test
+    fun `queue names should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf(
+            "queueid1" to validLocalstackQueueConfig(1).copy(queueName = "1stQueueName"),
+            "queueid2" to validLocalstackQueueConfig(2).copy(queueName = "2ndQueueName"),
+            "queueid3" to validLocalstackQueueConfig(3).copy(queueName = "1stQueueName")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated queue name")
+        .hasMessageContaining("1stQueueName")
+        .hasMessageNotContaining("2ndQueueName")
+    }
+
+    @Test
+    fun `dlq names should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf(
+            "queueid1" to validLocalstackQueueConfig(1).copy(dlqName = "1stDlqName"),
+            "queueid2" to validLocalstackQueueConfig(2).copy(dlqName = "2ndDlqName"),
+            "queueid3" to validLocalstackQueueConfig(3).copy(dlqName = "2ndDlqName")
+          ),
+          topics = mapOf()
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated dlq name")
+        .hasMessageContaining("2ndDlqName")
+        .hasMessageNotContaining("1stDlqName")
+    }
+
+    @Test
+    fun `dlq is optional`() {
+      assertThatNoException().isThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf(
+            "queueid1" to validLocalstackQueueNoDlqConfig(1),
+            "queueid2" to validLocalstackQueueNoDlqConfig(2),
+            "queueid3" to validLocalstackQueueNoDlqConfig(3)
+          ),
+          topics = mapOf()
+        )
+      }
+    }
+
+    @Test
+    fun `topic names should be unique`() {
+      assertThatThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf(),
+          topics = mapOf(
+            "topic1" to validLocalstackTopicConfig(1).copy(arn = "${localstackArnPrefix}1stName"),
+            "topic2" to validLocalstackTopicConfig(2).copy(arn = "${localstackArnPrefix}2ndName"),
+            "topic3" to validLocalstackTopicConfig(3).copy(arn = "${localstackArnPrefix}1stName")
+          )
+        )
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("Found duplicated topic names")
+        .hasMessageContaining("1stName")
+        .hasMessageNotContaining("2ndName")
+    }
+  }
+
+  @Nested
+  inner class TopicArnRegex {
+
+    @Test
+    fun `should retrieve name from valid topic arn`() {
+      val topicConfig = HmppsSqsProperties.TopicConfig(arn = "${localstackArnPrefix}some_topic_name")
+      val hmppsSqsProperties =
+        HmppsSqsProperties(provider = "localstack", queues = mapOf(), topics = mapOf("sometopicid" to topicConfig))
+
+      assertThat(hmppsSqsProperties.topics["sometopicid"]?.name).isEqualTo("some_topic_name")
+    }
+
+    @Test
+    fun `should throw if topic arn has invalid format`() {
+      val topicConfig = HmppsSqsProperties.TopicConfig(arn = "invalid_topic_name")
+      assertThatThrownBy {
+        HmppsSqsProperties(provider = "localstack", queues = mapOf(), topics = mapOf("sometopicid" to topicConfig))
+      }.isInstanceOf(InvalidHmppsSqsPropertiesException::class.java)
+        .hasMessageContaining("invalid_topic_name")
+        .hasMessageContaining("invalid format")
+    }
+  }
+
+  private fun validAwsQueueConfig(index: Int = 1) = HmppsSqsProperties.QueueConfig(
+    queueName = "name$index",
+    queueAccessKeyId = "key$index",
+    queueSecretAccessKey = "secret$index",
+    dlqName = "dlqName$index",
+    dlqAccessKeyId = "dlqKey$index",
+    dlqSecretAccessKey = "dlqSecret$index"
+  )
+
+  private fun validAwsQueueNoDlqConfig(index: Int = 1) = HmppsSqsProperties.QueueConfig(
+    queueName = "name$index",
+    queueAccessKeyId = "key$index",
+    queueSecretAccessKey = "secret$index"
+  )
+
+  private fun validAwsTopicConfig(index: Int = 1) =
+    HmppsSqsProperties.TopicConfig(arn = "arn$index", accessKeyId = "key$index", secretAccessKey = "secret$index")
+
+  private fun validLocalstackQueueConfig(index: Int = 1) =
+    HmppsSqsProperties.QueueConfig(queueName = "name$index", dlqName = "dlqName$index")
+
+  private fun validLocalstackQueueNoDlqConfig(index: Int = 1) = HmppsSqsProperties.QueueConfig(queueName = "name$index")
+  private fun validLocalstackTopicConfig(index: Int = 1) =
+    HmppsSqsProperties.TopicConfig(arn = "${localstackArnPrefix}$index")
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicFactoryTest.kt
@@ -1,0 +1,250 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.AmazonSNS
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.*
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.context.ConfigurableApplicationContext
+
+@Suppress("ClassName")
+class HmppsTopicFactoryTest {
+
+  private val localstackArnPrefix = "arn:aws:sns:eu-west-2:000000000000:"
+
+  private val context = mock<ConfigurableApplicationContext>()
+  private val beanFactory = mock<ConfigurableListableBeanFactory>()
+  private val snsFactory = mock<AmazonSnsFactory>()
+  private val hmppsTopicFactory = HmppsTopicFactory(context, snsFactory)
+
+  init {
+    whenever(context.beanFactory).thenReturn(beanFactory)
+  }
+
+  @Nested
+  inner class `Create AWS HmppsTopic` {
+    private val someTopicConfig =
+      HmppsSqsProperties.TopicConfig(
+        arn = "some arn",
+        accessKeyId = "some access key id",
+        secretAccessKey = "some secret access key"
+      )
+    private val hmppsSqsProperties =
+      HmppsSqsProperties(queues = mock(), topics = mapOf("sometopicid" to someTopicConfig))
+    private val snsClient = mock<AmazonSNS>()
+    private lateinit var hmppsTopics: List<HmppsTopic>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(snsFactory.awsSnsClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(snsClient)
+
+      hmppsTopics = hmppsTopicFactory.createHmppsTopics(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create aws sns client`() {
+      verify(snsFactory).awsSnsClient("sometopicid", "some access key id", "some secret access key", "eu-west-2")
+    }
+
+    @Test
+    fun `should return the topic details`() {
+      assertThat(hmppsTopics[0].id).isEqualTo("sometopicid")
+    }
+
+    @Test
+    fun `should return the AmazonSNS client`() {
+      assertThat(hmppsTopics[0].snsClient).isEqualTo(snsClient)
+    }
+
+    @Test
+    fun `should register the AmazonSNS client`() {
+      verify(beanFactory).registerSingleton("sometopicid-sns-client", snsClient)
+    }
+
+    @Test
+    fun `should register health indicators`() {
+      verify(beanFactory).registerSingleton(eq("sometopicid-health"), any<HealthIndicator>())
+    }
+  }
+
+  @Nested
+  inner class `Create LocalStack HmppsTopic` {
+    private val someTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "${localstackArnPrefix}some-topic-name",
+      accessKeyId = "some access key id",
+      secretAccessKey = "some secret access key"
+    )
+    private val hmppsSqsProperties =
+      HmppsSqsProperties(provider = "localstack", queues = mock(), topics = mapOf("sometopicid" to someTopicConfig))
+    private val snsClient = mock<AmazonSNS>()
+    private lateinit var hmppsTopics: List<HmppsTopic>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(snsFactory.localstackSnsClient(anyString(), anyString(), anyString()))
+        .thenReturn(snsClient)
+
+      hmppsTopics = hmppsTopicFactory.createHmppsTopics(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create localstack sns client`() {
+      verify(snsFactory).localstackSnsClient("sometopicid", "http://localhost:4566", "eu-west-2")
+    }
+
+    @Test
+    fun `should return the topic details`() {
+      assertThat(hmppsTopics[0].id).isEqualTo("sometopicid")
+    }
+
+    @Test
+    fun `should return the AmazonSNS client`() {
+      assertThat(hmppsTopics[0].snsClient).isEqualTo(snsClient)
+    }
+
+    @Test
+    fun `should register the AmazonSNS client`() {
+      verify(beanFactory).registerSingleton("sometopicid-sns-client", snsClient)
+    }
+
+    @Test
+    fun `should create the topic`() {
+      verify(snsClient).createTopic("some-topic-name")
+    }
+
+    @Test
+    fun `should register health indicators`() {
+      verify(beanFactory).registerSingleton(eq("sometopicid-health"), any<HealthIndicator>())
+    }
+  }
+
+  @Nested
+  inner class `Create multiple AWS HmppsTopics` {
+    private val someTopicConfig =
+      HmppsSqsProperties.TopicConfig(
+        arn = "some arn",
+        accessKeyId = "some access key id",
+        secretAccessKey = "some secret access key"
+      )
+    private val anotherTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "another arn",
+      accessKeyId = "another access key id",
+      secretAccessKey = "another secret access key"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(
+      queues = mock(),
+      topics = mapOf("sometopicid" to someTopicConfig, "anothertopicid" to anotherTopicConfig)
+    )
+    private val snsClient = mock<AmazonSNS>()
+    private lateinit var hmppsTopics: List<HmppsTopic>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(snsFactory.awsSnsClient(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(snsClient)
+        .thenReturn(snsClient)
+
+      hmppsTopics = hmppsTopicFactory.createHmppsTopics(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create 2 aws sns clients`() {
+      verify(snsFactory).awsSnsClient("sometopicid", "some access key id", "some secret access key", "eu-west-2")
+      verify(snsFactory).awsSnsClient(
+        "anothertopicid",
+        "another access key id",
+        "another secret access key",
+        "eu-west-2"
+      )
+    }
+
+    @Test
+    fun `should return the topic details`() {
+      assertThat(hmppsTopics[0].id).isEqualTo("sometopicid")
+      assertThat(hmppsTopics[1].id).isEqualTo("anothertopicid")
+    }
+
+    @Test
+    fun `should return 2 AmazonSNS client`() {
+      assertThat(hmppsTopics[0].snsClient).isEqualTo(snsClient)
+      assertThat(hmppsTopics[1].snsClient).isEqualTo(snsClient)
+    }
+
+    @Test
+    fun `should register 2 AmazonSNS clients`() {
+      verify(beanFactory).registerSingleton("sometopicid-sns-client", snsClient)
+      verify(beanFactory).registerSingleton("anothertopicid-sns-client", snsClient)
+    }
+
+    @Test
+    fun `should register 2 health indicators`() {
+      verify(beanFactory).registerSingleton(eq("sometopicid-health"), any<HealthIndicator>())
+      verify(beanFactory).registerSingleton(eq("anothertopicid-health"), any<HealthIndicator>())
+    }
+  }
+
+  @Nested
+  inner class `Create multiple LocalStack HmppsTopics` {
+    private val someTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "${localstackArnPrefix}some arn",
+      accessKeyId = "some access key id",
+      secretAccessKey = "some secret access key"
+    )
+    private val anotherTopicConfig = HmppsSqsProperties.TopicConfig(
+      arn = "${localstackArnPrefix}another arn",
+      accessKeyId = "another access key id",
+      secretAccessKey = "another secret access key"
+    )
+    private val hmppsSqsProperties = HmppsSqsProperties(
+      provider = "localstack",
+      queues = mock(),
+      topics = mapOf("sometopicid" to someTopicConfig, "anothertopicid" to anotherTopicConfig)
+    )
+    private val snsClient = mock<AmazonSNS>()
+    private lateinit var hmppsTopics: List<HmppsTopic>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(snsFactory.localstackSnsClient(anyString(), anyString(), anyString()))
+        .thenReturn(snsClient)
+        .thenReturn(snsClient)
+
+      hmppsTopics = hmppsTopicFactory.createHmppsTopics(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create 2 aws sns clients`() {
+      verify(snsFactory).localstackSnsClient("sometopicid", "http://localhost:4566", "eu-west-2")
+      verify(snsFactory).localstackSnsClient("anothertopicid", "http://localhost:4566", "eu-west-2")
+    }
+
+    @Test
+    fun `should return the topic details`() {
+      assertThat(hmppsTopics[0].id).isEqualTo("sometopicid")
+      assertThat(hmppsTopics[1].id).isEqualTo("anothertopicid")
+    }
+
+    @Test
+    fun `should return 2 AmazonSNS client`() {
+      assertThat(hmppsTopics[0].snsClient).isEqualTo(snsClient)
+      assertThat(hmppsTopics[1].snsClient).isEqualTo(snsClient)
+    }
+
+    @Test
+    fun `should register 2 AmazonSNS clients`() {
+      verify(beanFactory).registerSingleton("sometopicid-sns-client", snsClient)
+      verify(beanFactory).registerSingleton("anothertopicid-sns-client", snsClient)
+    }
+
+    @Test
+    fun `should register 2 health indicators`() {
+      verify(beanFactory).registerSingleton(eq("sometopicid-health"), any<HealthIndicator>())
+      verify(beanFactory).registerSingleton(eq("anothertopicid-health"), any<HealthIndicator>())
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicHealthTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/queue/HmppsTopicHealthTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.gdx.datashare.queue
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.GetTopicAttributesResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.actuate.health.Status
+
+class HmppsTopicHealthTest {
+
+  private val topicId = "some-topic-id"
+  private val topicArn = "some-topic-arn"
+  private val snsClient = mock<AmazonSNS>()
+  private val topicHealth = HmppsTopicHealth(HmppsTopic(topicId, topicArn, snsClient))
+
+  @Test
+  fun `should show status UP`() {
+    mockHealthyTopic()
+
+    val health = topicHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.UP)
+  }
+
+  @Test
+  fun `should show topic arn`() {
+    mockHealthyTopic()
+
+    val health = topicHealth.health()
+
+    assertThat(health.details["topicArn"]).isEqualTo("some-topic-arn")
+  }
+
+  @Test
+  fun `should show interesting topic attributes`() {
+    mockHealthyTopic()
+
+    val health = topicHealth.health()
+
+    assertThat(health.details["subscriptionsConfirmed"]).isEqualTo("1")
+    assertThat(health.details["subscriptionsPending"]).isEqualTo("2")
+  }
+
+  @Test
+  fun `should show status DOWN if cannot retrieve attributes`() {
+    mockUnhealthyTopic()
+
+    val health = topicHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should show exception if cannot retrieve attributes`() {
+    mockUnhealthyTopic()
+
+    val health = topicHealth.health()
+
+    assertThat(health.details["error"] as String).contains("Exception")
+    assertThat(health.details["error"] as String).contains("some exception")
+  }
+
+  fun mockUnhealthyTopic() {
+    whenever(snsClient.getTopicAttributes(anyString()))
+      .thenThrow(RuntimeException("some exception"))
+  }
+
+  fun mockHealthyTopic() {
+    whenever(snsClient.getTopicAttributes(anyString())).thenReturn(
+      GetTopicAttributesResult()
+        .withAttributes(mapOf("SubscriptionsConfirmed" to "1", "SubscriptionsPending" to "2"))
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -63,7 +63,6 @@ logging:
     io.r2dbc.postgresql.PARAM: INFO # for parameters
 
 hmpps.sqs:
-  reactiveApi: true
   provider: localstack
   queues:
     dataprocessor:


### PR DESCRIPTION
This is a bit of a thinking out loud more than an absolute must, but from the problems we had with ShedLock, I'd be keen to reduce the number of dependencies overall/have control over them, and particularly, have control over things like spring versions.

This is a lift of the bits of the SQS/SNS management that are required for our code to function and no more, and it's not massively complex code in the end either so I think the maintenance burden for us is quite low. I also think there are bits of the HMPPS code that are a useful general solution, but not something I think we really want in their current form (the DLQ retrying stuff for example, I think we want different control over to suit our use cases), so bringing that in to then be editable by us easily seems reasonable.