### PR TITLE
fix: Apply IAM credentials change immediately

### DIFF
--- a/terraform/modules/data-share-service/rds.tf
+++ b/terraform/modules/data-share-service/rds.tf
@@ -16,6 +16,7 @@ resource "aws_rds_cluster" "rds_postgres_cluster" {
   master_username                     = random_string.rds_username.result
   master_password                     = random_password.rds_password.result
   iam_database_authentication_enabled = true
+  apply_immediately                   = true # TODO ethmil: remove once applied
 
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"


### PR DESCRIPTION
Per https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html#:~:text=mydbinstance%20%5C%0A%20%20%20%20%2D-,%2Dapply%2Dimmediately,-%5C%0A%20%20%20%20%2D%2Denable%2Diam and https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#:~:text=can%20use%20the-,apply_immediately,-flag%20to%20instruct