### PR TITLE
chore: Make terraform and Kotlin format jobs add commit to a PR

### DIFF
--- a/.github/workflows/kotlin-lint-fix.yml
+++ b/.github/workflows/kotlin-lint-fix.yml
@@ -1,10 +1,7 @@
 name: Kotlin automatically fix linting
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - "main"
+  pull_request:
     paths:
       - "src/**"
 
@@ -12,6 +9,8 @@ jobs:
   tf-fmt:
     name: Validate and fix formatting
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -28,8 +27,8 @@ jobs:
       - name: Execute Gradle build
         run: ./gradlew clean formatKotlin
 
-      - name: Create pull request if required
-        uses: peter-evans/create-pull-request@v4
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          title: "housekeeping: Automatically format Kotlin files"
-          commit-message: "housekeeping: Automatically format Kotlin files"
+          commit_message: "housekeeping: Automatically reformat Kotlin files"
+          file_pattern: '*.kt'
+

--- a/.github/workflows/terraform-fmt-fix.yml
+++ b/.github/workflows/terraform-fmt-fix.yml
@@ -1,10 +1,7 @@
 name: Terraform automatically fix linting
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - "main"
+  pull_request:
     paths:
       - "terraform/**"
 
@@ -12,6 +9,8 @@ jobs:
   tf-fmt:
     name: Validate and fix formatting
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: terraform
@@ -27,8 +26,7 @@ jobs:
       - name: Check formatting of all Terraform files
         run: terraform fmt -recursive
 
-      - name: Create pull request if required
-        uses: peter-evans/create-pull-request@v4
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          title: "housekeeping: Automatically reformat terraform files"
-          commit-message: "housekeeping: Automatically reformat terraform files"
+          commit_message: "housekeeping: Automatically reformat terraform files"
+          file_pattern: '*.tf'


### PR DESCRIPTION
This makes the Kotlin and TF linters add a commit to a PR with any formatting changes required, hopefully only when you've touched relevant files.

This I think is generally better than just erroring - if it's a style opinion that we can automatically fix, lets do that.

The only relevant file changes (if this PR ends up adding some other files automatically!) are the workflow yml files.