### PR TITLE
fix: add startPeriod to healthcheck to allow container time to becom healthy

### DIFF
--- a/terraform/modules/data-share-service/ecs.tf
+++ b/terraform/modules/data-share-service/ecs.tf
@@ -67,7 +67,10 @@ resource "aws_ecs_task_definition" "gdx_data_share_poc" {
         { "name" : "LEGACY_OUTBOUND_API_CLIENT_ID", "value" : module.cognito.legacy_outbound_client_id },
         { "name" : "LEGACY_OUTBOUND_API_CLIENT_SECRET", "value" : module.cognito.legacy_outbound_client_secret },
 
-        { "name" : "SPRINGDOC_SWAGGER_UI_OAUTH2_REDIRECT_URL", "value" : "https://${aws_cloudfront_distribution.gdx_data_share_poc.domain_name}/webjars/swagger-ui/oauth2-redirect.html" },
+        {
+          "name" : "SPRINGDOC_SWAGGER_UI_OAUTH2_REDIRECT_URL",
+          "value" : "https://${aws_cloudfront_distribution.gdx_data_share_poc.domain_name}/webjars/swagger-ui/oauth2-redirect.html"
+        },
       ]
       logConfiguration : {
         logDriver : "awslogs",
@@ -79,7 +82,8 @@ resource "aws_ecs_task_definition" "gdx_data_share_poc" {
         }
       },
       healthCheck : {
-        command : ["CMD", "curl -f http://localhost:8080/health/ping"]
+        command : ["CMD-SHELL", "curl -f http://localhost:8080/health/ping || exit 1"],
+        startPeriod : 180
       }
     }
   ])


### PR DESCRIPTION
This is more generous than it needs to be because the docs indicate that it will still attempt health checks during this period and the container can become healthy before the startPeriod has elapsed

[If a health check succeeds within the startPeriod, then the container is considered healthy and any subsequent failures count toward the maximum number of retries.](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#:~:text=If%20a%20health%20check%20succeeds%20within%20the%20startPeriod%2C%20then%20the%20container%20is%20considered%20healthy%20and%20any%20subsequent%20failures%20count%20toward%20the%20maximum%20number%20of%20retries.)