### PR TITLE
fix: set connection params for webclient

### DIFF
--- a/src/main/kotlin/uk/gov/gdx/datashare/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/config/WebClientConfiguration.kt
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
+import reactor.netty.resources.ConnectionProvider
 import java.time.Duration
 
 @Configuration
@@ -21,7 +22,14 @@ class WebClientConfiguration(
 
   @Bean
   fun levApiWebClient(): WebClient {
-    val httpClient = HttpClient.create().responseTimeout(Duration.ofMinutes(2))
+    val connectionProvider = ConnectionProvider.builder("levApi")
+      .maxConnections(100)
+      .maxIdleTime(Duration.ofSeconds(20))
+      .maxLifeTime(Duration.ofSeconds(60))
+      .pendingAcquireTimeout(Duration.ofSeconds(60))
+      .evictInBackground(Duration.ofSeconds(120))
+      .build()
+    val httpClient = HttpClient.create(connectionProvider).responseTimeout(Duration.ofSeconds(10))
     return WebClient.builder()
       .baseUrl(levApiRootUri)
       .clientConnector(ReactorClientHttpConnector(httpClient))


### PR DESCRIPTION
Aims to prevent connection closed by client errors https://github.com/reactor/reactor-netty/issues/1774