### PR TITLE
chore: increase get events page size

### DIFF
--- a/terraform/modules/consumer/lambdas/get_events.py
+++ b/terraform/modules/consumer/lambdas/get_events.py
@@ -63,7 +63,7 @@ def lambda_handler(event, _context):
 
 
 def get_first_events_page(auth_token: str):
-    return get_data(auth_token, events_url + "?page%5Bsize%5D=20")
+    return get_data(auth_token, events_url + "?page%5Bsize%5D=100")
 
 
 def get_data(auth_token: str, url: str):


### PR DESCRIPTION
At peak, this will need to fetch around 1500 events given it runs every 30 minutes. A page size of 20 is too low to fetch this many in the 10 second lambda execution limit