### PR TITLE
GPC-69: Retry LocalStack startup to stabilise builds

### DIFF
--- a/src/test/kotlin/uk/gov/gdx/datashare/integration/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/integration/LocalStackContainer.kt
@@ -28,6 +28,7 @@ object LocalStackContainer {
     ).apply {
       withServices(LocalStackContainer.Service.SQS, LocalStackContainer.Service.SNS, LocalStackContainer.Service.S3)
       withEnv("DEFAULT_REGION", "eu-west-2")
+      withStartupAttempts(3)
       waitingFor(
         Wait.forLogMessage(".*Running on.*", 1),
       )


### PR DESCRIPTION
This is a slightly optimistic thing, but I  think giving LocalStack a couple of attempts to start up seems reasonable