### PR TITLE
GPC-82: Add runbook for deployment failures

### DIFF
--- a/doc/runbooks/deployment-failures.md
+++ b/doc/runbooks/deployment-failures.md
@@ -6,5 +6,7 @@
 
 ## How do you resolve it?
 
-- review logs in CloudWatch
-- review logs from CodeDeploy?
+Review logs from the ECS task
+- under Elastic Container Services find the affected cluster
+- identify the service, e.g. `dev-gdx-data-share-poc`
+-- at a service level you can see logs for all instances, you can also find logs for specific pending instances

--- a/doc/runbooks/deployment-failures.md
+++ b/doc/runbooks/deployment-failures.md
@@ -1,0 +1,10 @@
+# Deployment Failures
+
+## Identifying a failure?
+
+- GitHub Actions timeout for a deployment
+
+## How do you resolve it?
+
+- review logs in CloudWatch
+- review logs from CodeDeploy?


### PR DESCRIPTION
This might be a very wrong thing, but from discussion at planning here's a rough starter