### PR TITLE
GPC-NONE: move deploy hook lambdas to private subnet

### DIFF
--- a/terraform/modules/data-share-service/deploy_hook.tf
+++ b/terraform/modules/data-share-service/deploy_hook.tf
@@ -6,7 +6,7 @@ module "deploy_hook" {
   codedeploy_arn              = aws_codedeploy_app.gdx_data_share_poc.arn
 
   security_group_id = aws_security_group.lambda.id
-  subnet_ids        = module.vpc.public_subnet_ids
+  subnet_ids        = module.vpc.private_subnet_ids
 
   test_gdx_url  = "http://${aws_lb.load_balancer.dns_name}:8080"
   auth_url      = module.cognito.token_auth_url

--- a/terraform/modules/data-share-service/vpc.tf
+++ b/terraform/modules/data-share-service/vpc.tf
@@ -1,5 +1,4 @@
 #tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
-#tfsec:ignore:aws-ec2-no-public-ip-subnet
 module "vpc" {
   source = "git::https://github.com/Softwire/terraform-vpc-aws?ref=dcc0cee3eafc5578d93479bb7798c22a8e5baba1"
 
@@ -9,8 +8,6 @@ module "vpc" {
   # At least two availability zones are required in order to set up a load balancer, so that the
   # infrastructure is kept consistent with other environments which use multiple availability zones.
   availability_zones = data.aws_availability_zones.available.zone_ids
-
-  map_public_subnet_public_ips = true
 
   tags_default = {
     Environment = var.environment


### PR DESCRIPTION
This is fine and can access everything in the public subnet. However, the lb has no fixed private IP, so we cannot call it internal to the vpc. We'll need to allow public access on 8080 and do header based auth I think