### PR TITLE
GPC-NONE: Restructure event handling

### DIFF
--- a/src/main/kotlin/uk/gov/gdx/datashare/services/DeathNotificationService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/DeathNotificationService.kt
@@ -26,6 +26,6 @@ class DeathNotificationService(
     return levApiService
       .findDeathById(citizenDeathId)
       .map { DeathNotificationDetails.fromLevDeathRecord(enrichmentFields, it) }
-      .first();
+      .first()
   }
 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/DeathNotificationService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/DeathNotificationService.kt
@@ -17,22 +17,15 @@ class DeathNotificationService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getEnrichedPayload(
-    dataId: String,
-    enrichmentFields: List<EnrichmentField>,
-  ): DeathNotificationDetails? {
-    val citizenDeathId = dataId.toInt()
-    return levApiService
-      .findDeathById(citizenDeathId)
-      .map { DeathNotificationDetails.fromLevDeathRecord(enrichmentFields, it) }
-      .first()
-  }
-
   override fun accepts(eventType: EventType): Boolean {
     return eventType == EventType.DEATH_NOTIFICATION
   }
 
-  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {
-    return getEnrichedPayload(dataId, enrichmentFields);
+  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): DeathNotificationDetails? {
+    val citizenDeathId = dataId.toInt()
+    return levApiService
+      .findDeathById(citizenDeathId)
+      .map { DeathNotificationDetails.fromLevDeathRecord(enrichmentFields, it) }
+      .first();
   }
 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/DeathNotificationService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/DeathNotificationService.kt
@@ -5,13 +5,14 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.models.DeathNotificationDetails
 
 @Service
 @XRayEnabled
 class DeathNotificationService(
   private val levApiService: LevApiService,
-) {
+) : EnrichmentService {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -25,5 +26,13 @@ class DeathNotificationService(
       .findDeathById(citizenDeathId)
       .map { DeathNotificationDetails.fromLevDeathRecord(enrichmentFields, it) }
       .first()
+  }
+
+  override fun accepts(eventType: EventType): Boolean {
+    return eventType == EventType.DEATH_NOTIFICATION
+  }
+
+  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {
+    return getEnrichedPayload(dataId, enrichmentFields);
   }
 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/EnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/EnrichmentService.kt
@@ -1,12 +1,13 @@
-package uk.gov.gdx.datashare.services;
+package uk.gov.gdx.datashare.services
 
 import uk.gov.gdx.datashare.enums.EnrichmentField
-import uk.gov.gdx.datashare.enums.EventType;
+import uk.gov.gdx.datashare.enums.EventType
 
 interface EnrichmentService {
-    fun accepts(eventType: EventType): Boolean
-    fun process(eventType: EventType,
-                dataId: String,
-                enrichmentFields: List<EnrichmentField>): Any?
-
+  fun accepts(eventType: EventType): Boolean
+  fun process(
+    eventType: EventType,
+    dataId: String,
+    enrichmentFields: List<EnrichmentField>,
+  ): Any?
 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/EnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/EnrichmentService.kt
@@ -1,0 +1,12 @@
+package uk.gov.gdx.datashare.services;
+
+import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType;
+
+interface EnrichmentService {
+    fun accepts(eventType: EventType): Boolean
+    fun process(eventType: EventType,
+                dataId: String,
+                enrichmentFields: List<EnrichmentField>): Any?
+
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/NullEventEnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/NullEventEnrichmentService.kt
@@ -1,0 +1,26 @@
+package uk.gov.gdx.datashare.services
+
+import com.amazonaws.xray.spring.aop.XRayEnabled
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Service
+import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType
+
+@Service
+@Order(value = Ordered.LOWEST_PRECEDENCE)
+@XRayEnabled
+class NullEventEnrichmentService : EnrichmentService {
+  override fun accepts(eventType: EventType): Boolean = true
+
+  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {
+    log.warn("Not handling this event type {}", eventType)
+    return null
+  }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/PrisonerLookupService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/PrisonerLookupService.kt
@@ -5,6 +5,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.enums.Sex
 import uk.gov.gdx.datashare.models.PrisonerDetails
 import uk.gov.gdx.datashare.models.PrisonerRecord
@@ -13,7 +14,7 @@ import uk.gov.gdx.datashare.models.PrisonerRecord
 @XRayEnabled
 class PrisonerLookupService(
   private val prisonerApiService: PrisonerApiService,
-) {
+) : EnrichmentService {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -31,7 +32,11 @@ class PrisonerLookupService(
     prisonerRecord: PrisonerRecord,
     ef: List<EnrichmentField>,
   ): PrisonerDetails {
-    val sex = when (prisonerRecord.gender) { "Female" -> Sex.FEMALE "Male" -> Sex.MALE else -> Sex.INDETERMINATE }
+    val sex = when (prisonerRecord.gender) {
+      "Female" -> Sex.FEMALE
+      "Male" -> Sex.MALE
+      else -> Sex.INDETERMINATE
+    }
     return PrisonerDetails(
       prisonerNumber = if (ef.contains(EnrichmentField.PRISONER_NUMBER)) prisonerRecord.prisonerNumber else null,
       firstName = if (ef.contains(EnrichmentField.FIRST_NAME)) prisonerRecord.firstName else null,
@@ -40,5 +45,13 @@ class PrisonerLookupService(
       sex = if (ef.contains(EnrichmentField.SEX)) sex else null,
       dateOfBirth = if (ef.contains(EnrichmentField.DATE_OF_BIRTH)) prisonerRecord.dateOfBirth else null,
     )
+  }
+
+  override fun accepts(eventType: EventType): Boolean {
+    return eventType == EventType.ENTERED_PRISON
+  }
+
+  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {
+    return getEnrichedPayload(dataId, enrichmentFields)
   }
 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/PrisonerLookupService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/PrisonerLookupService.kt
@@ -19,11 +19,16 @@ class PrisonerLookupService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getEnrichedPayload(
-    prisonerNumber: String,
+  override fun accepts(eventType: EventType): Boolean {
+    return eventType == EventType.ENTERED_PRISON
+  }
+
+  override fun process(
+    eventType: EventType,
+    dataId: String,
     enrichmentFields: List<EnrichmentField>,
   ): PrisonerDetails? {
-    val allEnrichedData = prisonerApiService.findPrisonerById(prisonerNumber)
+    val allEnrichedData = prisonerApiService.findPrisonerById(dataId)
 
     return allEnrichedData?.let { mapPrisonerRecord(it, enrichmentFields) }
   }
@@ -45,13 +50,5 @@ class PrisonerLookupService(
       sex = if (ef.contains(EnrichmentField.SEX)) sex else null,
       dateOfBirth = if (ef.contains(EnrichmentField.DATE_OF_BIRTH)) prisonerRecord.dateOfBirth else null,
     )
-  }
-
-  override fun accepts(eventType: EventType): Boolean {
-    return eventType == EventType.ENTERED_PRISON
-  }
-
-  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {
-    return getEnrichedPayload(dataId, enrichmentFields)
   }
 }

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/TestEventEnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/TestEventEnrichmentService.kt
@@ -1,0 +1,19 @@
+package uk.gov.gdx.datashare.services
+
+import com.amazonaws.xray.spring.aop.XRayEnabled
+import org.springframework.stereotype.Service
+import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType
+import uk.gov.gdx.datashare.models.TestEvent
+
+@Service
+@XRayEnabled
+class TestEventEnrichmentService : EnrichmentService {
+  override fun accepts(eventType: EventType): Boolean {
+    return eventType == EventType.TEST_EVENT;
+  }
+
+  override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {
+    return TestEvent(testField = "Test Field Value")
+  }
+}

--- a/src/main/kotlin/uk/gov/gdx/datashare/services/TestEventEnrichmentService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/TestEventEnrichmentService.kt
@@ -10,7 +10,7 @@ import uk.gov.gdx.datashare.models.TestEvent
 @XRayEnabled
 class TestEventEnrichmentService : EnrichmentService {
   override fun accepts(eventType: EventType): Boolean {
-    return eventType == EventType.TEST_EVENT;
+    return eventType == EventType.TEST_EVENT
   }
 
   override fun process(eventType: EventType, dataId: String, enrichmentFields: List<EnrichmentField>): Any? {

--- a/src/test/kotlin/uk/gov/gdx/datashare/services/DeathNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/services/DeathNotificationServiceTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.enums.EnrichmentField
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.enums.Sex
-import uk.gov.gdx.datashare.models.DeathNotificationDetails
 import uk.gov.gdx.datashare.models.LevDeathRecord
 import uk.gov.gdx.datashare.models.LevDeceased
 import java.time.LocalDate
@@ -19,96 +18,96 @@ class DeathNotificationServiceTest {
 
   @Test
   fun `getEnrichedData returns all data for a full set of enrichment fields`() {
-      val dataId = "123456789"
-      val enrichmentFields = listOf(
-          EnrichmentField.REGISTRATION_DATE,
-          EnrichmentField.FIRST_NAMES,
-          EnrichmentField.LAST_NAME,
-          EnrichmentField.SEX,
-          EnrichmentField.DATE_OF_DEATH,
-          EnrichmentField.MAIDEN_NAME,
-          EnrichmentField.DATE_OF_BIRTH,
-          EnrichmentField.ADDRESS,
-          EnrichmentField.BIRTH_PLACE,
-          EnrichmentField.DEATH_PLACE,
-          EnrichmentField.OCCUPATION,
-          EnrichmentField.RETIRED,
-      )
-      val deathRecord = LevDeathRecord(
-          deceased = LevDeceased(
-              forenames = "Alice",
-              surname = "Smith",
-              dateOfBirth = LocalDate.of(1920, 1, 1),
-              dateOfDeath = LocalDate.of(2010, 1, 1),
-              sex = Sex.FEMALE,
-              address = "666 Inform House, 6 Inform street, Informington, Informshire",
-              birthplace = "Hospital",
-              deathplace = "Home",
-              maidenSurname = "Jones",
-              occupation = "Doctor",
-              retired = true,
-          ),
-          id = dataId,
-          date = LocalDate.now(),
-      )
+    val dataId = "123456789"
+    val enrichmentFields = listOf(
+      EnrichmentField.REGISTRATION_DATE,
+      EnrichmentField.FIRST_NAMES,
+      EnrichmentField.LAST_NAME,
+      EnrichmentField.SEX,
+      EnrichmentField.DATE_OF_DEATH,
+      EnrichmentField.MAIDEN_NAME,
+      EnrichmentField.DATE_OF_BIRTH,
+      EnrichmentField.ADDRESS,
+      EnrichmentField.BIRTH_PLACE,
+      EnrichmentField.DEATH_PLACE,
+      EnrichmentField.OCCUPATION,
+      EnrichmentField.RETIRED,
+    )
+    val deathRecord = LevDeathRecord(
+      deceased = LevDeceased(
+        forenames = "Alice",
+        surname = "Smith",
+        dateOfBirth = LocalDate.of(1920, 1, 1),
+        dateOfDeath = LocalDate.of(2010, 1, 1),
+        sex = Sex.FEMALE,
+        address = "666 Inform House, 6 Inform street, Informington, Informshire",
+        birthplace = "Hospital",
+        deathplace = "Home",
+        maidenSurname = "Jones",
+        occupation = "Doctor",
+        retired = true,
+      ),
+      id = dataId,
+      date = LocalDate.now(),
+    )
 
-      every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
+    every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
 
     val enrichedPayload = underTest.process(EventType.DEATH_NOTIFICATION, dataId, enrichmentFields)!!
 
-      assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
-      assertThat(enrichedPayload.lastName).isEqualTo(deathRecord.deceased.surname)
-      assertThat(enrichedPayload.dateOfBirth).isEqualTo(deathRecord.deceased.dateOfBirth)
-      assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
-      assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
-      assertThat(enrichedPayload.registrationDate).isEqualTo(deathRecord.date)
-      assertThat(enrichedPayload.birthPlace).isEqualTo(deathRecord.deceased.birthplace)
-      assertThat(enrichedPayload.deathPlace).isEqualTo(deathRecord.deceased.deathplace)
-      assertThat(enrichedPayload.maidenName).isEqualTo(deathRecord.deceased.maidenSurname)
-      assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
+    assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
+    assertThat(enrichedPayload.lastName).isEqualTo(deathRecord.deceased.surname)
+    assertThat(enrichedPayload.dateOfBirth).isEqualTo(deathRecord.deceased.dateOfBirth)
+    assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
+    assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
+    assertThat(enrichedPayload.registrationDate).isEqualTo(deathRecord.date)
+    assertThat(enrichedPayload.birthPlace).isEqualTo(deathRecord.deceased.birthplace)
+    assertThat(enrichedPayload.deathPlace).isEqualTo(deathRecord.deceased.deathplace)
+    assertThat(enrichedPayload.maidenName).isEqualTo(deathRecord.deceased.maidenSurname)
+    assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
   }
 
   @Test
   fun `getEnrichedData returns correct data for a subset of enrichment fields`() {
-      val dataId = "123456789"
-      val enrichmentFields = listOf(
-          EnrichmentField.FIRST_NAMES,
-          EnrichmentField.DATE_OF_DEATH,
-          EnrichmentField.ADDRESS,
-          EnrichmentField.RETIRED,
-      )
-      val deathRecord = LevDeathRecord(
-          deceased = LevDeceased(
-              forenames = "Alice",
-              surname = "Smith",
-              dateOfBirth = LocalDate.of(1920, 1, 1),
-              dateOfDeath = LocalDate.of(2010, 1, 1),
-              sex = Sex.FEMALE,
-              address = "666 Inform House, 6 Inform street, Informington, Informshire",
-              birthplace = "Hospital",
-              deathplace = "Home",
-              maidenSurname = "Jones",
-              occupation = "Doctor",
-              retired = true,
-          ),
-          id = dataId,
-          date = LocalDate.now(),
-      )
+    val dataId = "123456789"
+    val enrichmentFields = listOf(
+      EnrichmentField.FIRST_NAMES,
+      EnrichmentField.DATE_OF_DEATH,
+      EnrichmentField.ADDRESS,
+      EnrichmentField.RETIRED,
+    )
+    val deathRecord = LevDeathRecord(
+      deceased = LevDeceased(
+        forenames = "Alice",
+        surname = "Smith",
+        dateOfBirth = LocalDate.of(1920, 1, 1),
+        dateOfDeath = LocalDate.of(2010, 1, 1),
+        sex = Sex.FEMALE,
+        address = "666 Inform House, 6 Inform street, Informington, Informshire",
+        birthplace = "Hospital",
+        deathplace = "Home",
+        maidenSurname = "Jones",
+        occupation = "Doctor",
+        retired = true,
+      ),
+      id = dataId,
+      date = LocalDate.now(),
+    )
 
-      every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
+    every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
 
     val enrichedPayload = underTest.process(EventType.DEATH_NOTIFICATION, dataId, enrichmentFields)!!
 
-      assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
-      assertThat(enrichedPayload.lastName).isNull()
-      assertThat(enrichedPayload.dateOfBirth).isNull()
-      assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
-      assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
-      assertThat(enrichedPayload.sex).isNull()
-      assertThat(enrichedPayload.registrationDate).isNull()
-      assertThat(enrichedPayload.birthPlace).isNull()
-      assertThat(enrichedPayload.deathPlace).isNull()
-      assertThat(enrichedPayload.maidenName).isNull()
-      assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
+    assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
+    assertThat(enrichedPayload.lastName).isNull()
+    assertThat(enrichedPayload.dateOfBirth).isNull()
+    assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
+    assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
+    assertThat(enrichedPayload.sex).isNull()
+    assertThat(enrichedPayload.registrationDate).isNull()
+    assertThat(enrichedPayload.birthPlace).isNull()
+    assertThat(enrichedPayload.deathPlace).isNull()
+    assertThat(enrichedPayload.maidenName).isNull()
+    assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
   }
 }

--- a/src/test/kotlin/uk/gov/gdx/datashare/services/DeathNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/services/DeathNotificationServiceTest.kt
@@ -5,7 +5,9 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.enums.Sex
+import uk.gov.gdx.datashare.models.DeathNotificationDetails
 import uk.gov.gdx.datashare.models.LevDeathRecord
 import uk.gov.gdx.datashare.models.LevDeceased
 import java.time.LocalDate
@@ -17,96 +19,96 @@ class DeathNotificationServiceTest {
 
   @Test
   fun `getEnrichedData returns all data for a full set of enrichment fields`() {
-    val dataId = "123456789"
-    val enrichmentFields = listOf(
-      EnrichmentField.REGISTRATION_DATE,
-      EnrichmentField.FIRST_NAMES,
-      EnrichmentField.LAST_NAME,
-      EnrichmentField.SEX,
-      EnrichmentField.DATE_OF_DEATH,
-      EnrichmentField.MAIDEN_NAME,
-      EnrichmentField.DATE_OF_BIRTH,
-      EnrichmentField.ADDRESS,
-      EnrichmentField.BIRTH_PLACE,
-      EnrichmentField.DEATH_PLACE,
-      EnrichmentField.OCCUPATION,
-      EnrichmentField.RETIRED,
-    )
-    val deathRecord = LevDeathRecord(
-      deceased = LevDeceased(
-        forenames = "Alice",
-        surname = "Smith",
-        dateOfBirth = LocalDate.of(1920, 1, 1),
-        dateOfDeath = LocalDate.of(2010, 1, 1),
-        sex = Sex.FEMALE,
-        address = "666 Inform House, 6 Inform street, Informington, Informshire",
-        birthplace = "Hospital",
-        deathplace = "Home",
-        maidenSurname = "Jones",
-        occupation = "Doctor",
-        retired = true,
-      ),
-      id = dataId,
-      date = LocalDate.now(),
-    )
+      val dataId = "123456789"
+      val enrichmentFields = listOf(
+          EnrichmentField.REGISTRATION_DATE,
+          EnrichmentField.FIRST_NAMES,
+          EnrichmentField.LAST_NAME,
+          EnrichmentField.SEX,
+          EnrichmentField.DATE_OF_DEATH,
+          EnrichmentField.MAIDEN_NAME,
+          EnrichmentField.DATE_OF_BIRTH,
+          EnrichmentField.ADDRESS,
+          EnrichmentField.BIRTH_PLACE,
+          EnrichmentField.DEATH_PLACE,
+          EnrichmentField.OCCUPATION,
+          EnrichmentField.RETIRED,
+      )
+      val deathRecord = LevDeathRecord(
+          deceased = LevDeceased(
+              forenames = "Alice",
+              surname = "Smith",
+              dateOfBirth = LocalDate.of(1920, 1, 1),
+              dateOfDeath = LocalDate.of(2010, 1, 1),
+              sex = Sex.FEMALE,
+              address = "666 Inform House, 6 Inform street, Informington, Informshire",
+              birthplace = "Hospital",
+              deathplace = "Home",
+              maidenSurname = "Jones",
+              occupation = "Doctor",
+              retired = true,
+          ),
+          id = dataId,
+          date = LocalDate.now(),
+      )
 
-    every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
+      every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
 
-    val enrichedPayload = underTest.getEnrichedPayload(dataId, enrichmentFields)!!
+    val enrichedPayload = underTest.process(EventType.DEATH_NOTIFICATION, dataId, enrichmentFields)!!
 
-    assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
-    assertThat(enrichedPayload.lastName).isEqualTo(deathRecord.deceased.surname)
-    assertThat(enrichedPayload.dateOfBirth).isEqualTo(deathRecord.deceased.dateOfBirth)
-    assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
-    assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
-    assertThat(enrichedPayload.registrationDate).isEqualTo(deathRecord.date)
-    assertThat(enrichedPayload.birthPlace).isEqualTo(deathRecord.deceased.birthplace)
-    assertThat(enrichedPayload.deathPlace).isEqualTo(deathRecord.deceased.deathplace)
-    assertThat(enrichedPayload.maidenName).isEqualTo(deathRecord.deceased.maidenSurname)
-    assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
+      assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
+      assertThat(enrichedPayload.lastName).isEqualTo(deathRecord.deceased.surname)
+      assertThat(enrichedPayload.dateOfBirth).isEqualTo(deathRecord.deceased.dateOfBirth)
+      assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
+      assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
+      assertThat(enrichedPayload.registrationDate).isEqualTo(deathRecord.date)
+      assertThat(enrichedPayload.birthPlace).isEqualTo(deathRecord.deceased.birthplace)
+      assertThat(enrichedPayload.deathPlace).isEqualTo(deathRecord.deceased.deathplace)
+      assertThat(enrichedPayload.maidenName).isEqualTo(deathRecord.deceased.maidenSurname)
+      assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
   }
 
   @Test
   fun `getEnrichedData returns correct data for a subset of enrichment fields`() {
-    val dataId = "123456789"
-    val enrichmentFields = listOf(
-      EnrichmentField.FIRST_NAMES,
-      EnrichmentField.DATE_OF_DEATH,
-      EnrichmentField.ADDRESS,
-      EnrichmentField.RETIRED,
-    )
-    val deathRecord = LevDeathRecord(
-      deceased = LevDeceased(
-        forenames = "Alice",
-        surname = "Smith",
-        dateOfBirth = LocalDate.of(1920, 1, 1),
-        dateOfDeath = LocalDate.of(2010, 1, 1),
-        sex = Sex.FEMALE,
-        address = "666 Inform House, 6 Inform street, Informington, Informshire",
-        birthplace = "Hospital",
-        deathplace = "Home",
-        maidenSurname = "Jones",
-        occupation = "Doctor",
-        retired = true,
-      ),
-      id = dataId,
-      date = LocalDate.now(),
-    )
+      val dataId = "123456789"
+      val enrichmentFields = listOf(
+          EnrichmentField.FIRST_NAMES,
+          EnrichmentField.DATE_OF_DEATH,
+          EnrichmentField.ADDRESS,
+          EnrichmentField.RETIRED,
+      )
+      val deathRecord = LevDeathRecord(
+          deceased = LevDeceased(
+              forenames = "Alice",
+              surname = "Smith",
+              dateOfBirth = LocalDate.of(1920, 1, 1),
+              dateOfDeath = LocalDate.of(2010, 1, 1),
+              sex = Sex.FEMALE,
+              address = "666 Inform House, 6 Inform street, Informington, Informshire",
+              birthplace = "Hospital",
+              deathplace = "Home",
+              maidenSurname = "Jones",
+              occupation = "Doctor",
+              retired = true,
+          ),
+          id = dataId,
+          date = LocalDate.now(),
+      )
 
-    every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
+      every { levApiService.findDeathById(dataId.toInt()) }.returns(listOf(deathRecord))
 
-    val enrichedPayload = underTest.getEnrichedPayload(dataId, enrichmentFields)!!
+    val enrichedPayload = underTest.process(EventType.DEATH_NOTIFICATION, dataId, enrichmentFields)!!
 
-    assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
-    assertThat(enrichedPayload.lastName).isNull()
-    assertThat(enrichedPayload.dateOfBirth).isNull()
-    assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
-    assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
-    assertThat(enrichedPayload.sex).isNull()
-    assertThat(enrichedPayload.registrationDate).isNull()
-    assertThat(enrichedPayload.birthPlace).isNull()
-    assertThat(enrichedPayload.deathPlace).isNull()
-    assertThat(enrichedPayload.maidenName).isNull()
-    assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
+      assertThat(enrichedPayload.firstNames).isEqualTo(deathRecord.deceased.forenames)
+      assertThat(enrichedPayload.lastName).isNull()
+      assertThat(enrichedPayload.dateOfBirth).isNull()
+      assertThat(enrichedPayload.dateOfDeath).isEqualTo(deathRecord.deceased.dateOfDeath)
+      assertThat(enrichedPayload.address).isEqualTo(deathRecord.deceased.address)
+      assertThat(enrichedPayload.sex).isNull()
+      assertThat(enrichedPayload.registrationDate).isNull()
+      assertThat(enrichedPayload.birthPlace).isNull()
+      assertThat(enrichedPayload.deathPlace).isNull()
+      assertThat(enrichedPayload.maidenName).isNull()
+      assertThat(enrichedPayload.retired).isEqualTo(deathRecord.deceased.retired)
   }
 }

--- a/src/test/kotlin/uk/gov/gdx/datashare/services/EventDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/services/EventDataServiceTest.kt
@@ -89,11 +89,13 @@ class EventDataServiceTest {
     every { eventDataRepository.findByClientIdAndId(clientId, event.id) }.returns(event)
     every { acquirerSubscriptionRepository.findByEventId(event.id) }.returns(deathNotificationSubscription)
     every {
-      deathNotificationService.getEnrichedPayload(
-        event.dataId,
+      deathNotificationService.process(
+        EventType.DEATH_NOTIFICATION,
+      event.dataId,
         subscriptionEnrichmentFields,
       )
     }.returns(deathNotificationDetails)
+    every { deathNotificationService.accepts(eventType = EventType.DEATH_NOTIFICATION) }.returns(true)
     every { acquirerSubscriptionEnrichmentFieldRepository.findAllByAcquirerSubscriptionId(any()) }.returns(
       deathNotificationEnrichmentFields,
     )
@@ -169,11 +171,13 @@ class EventDataServiceTest {
       )
     }.returns(deathEvents.count())
     every {
-      deathNotificationService.getEnrichedPayload(
+      deathNotificationService.process(
+        EventType.DEATH_NOTIFICATION,
         any(),
         subscriptionEnrichmentFields,
       )
     }.returns(deathNotificationDetails)
+    every { deathNotificationService.accepts(eventType = EventType.DEATH_NOTIFICATION) }.returns(true)
     every { acquirerSubscriptionEnrichmentFieldRepository.findAllByAcquirerSubscriptionId(any()) }.returns(
       deathNotificationEnrichmentFields,
     )
@@ -231,11 +235,13 @@ class EventDataServiceTest {
       )
     }.returns(totalEventCount)
     every {
-      deathNotificationService.getEnrichedPayload(
+      deathNotificationService.process(
+        eventType = EventType.DEATH_NOTIFICATION,
         any(),
         subscriptionEnrichmentFields,
       )
     }.returns(deathNotificationDetails)
+    every { deathNotificationService.accepts(eventType = EventType.DEATH_NOTIFICATION) }.returns(true)
     every { acquirerSubscriptionEnrichmentFieldRepository.findAllByAcquirerSubscriptionId(any()) }.returns(
       deathNotificationEnrichmentFields,
     )
@@ -340,11 +346,13 @@ class EventDataServiceTest {
       )
     }.returns(extraDeathEvents.count())
     every {
-      deathNotificationService.getEnrichedPayload(
+      deathNotificationService.process(
+        EventType.DEATH_NOTIFICATION,
         any(),
         subscriptionEnrichmentFields,
       )
     }.returns(deathNotificationDetails)
+    every { deathNotificationService.accepts(eventType = EventType.DEATH_NOTIFICATION) }.returns(true)
     every { acquirerSubscriptionEnrichmentFieldRepository.findAllByAcquirerSubscriptionId(any()) }.returns(
       deathNotificationEnrichmentFields,
     )

--- a/src/test/kotlin/uk/gov/gdx/datashare/services/EventDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/services/EventDataServiceTest.kt
@@ -91,7 +91,7 @@ class EventDataServiceTest {
     every {
       deathNotificationService.process(
         EventType.DEATH_NOTIFICATION,
-      event.dataId,
+        event.dataId,
         subscriptionEnrichmentFields,
       )
     }.returns(deathNotificationDetails)

--- a/src/test/kotlin/uk/gov/gdx/datashare/services/EventDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/services/EventDataServiceTest.kt
@@ -58,6 +58,12 @@ class EventDataServiceTest {
       dateTimeHandler,
       meterRegistry,
       acquirerSubscriptionEnrichmentFieldRepository,
+      listOf(
+        deathNotificationService,
+        prisonerLookupService,
+        TestEventEnrichmentService(),
+        NullEventEnrichmentService(),
+      ),
     )
   }
 

--- a/src/test/kotlin/uk/gov/gdx/datashare/services/PrisonerLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/services/PrisonerLookupServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.enums.EnrichmentField
+import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.enums.Sex
 import uk.gov.gdx.datashare.models.PrisonerRecord
 import uk.gov.gdx.datashare.services.PrisonerApiService
@@ -40,7 +41,7 @@ class PrisonerLookupServiceTest {
 
     every { prisonerApiService.findPrisonerById(dataId) }.returns(prisonerRecord)
 
-    val enrichedPayload = underTest.getEnrichedPayload(dataId, enrichmentFields)!!
+    val enrichedPayload = underTest.process(EventType.ENTERED_PRISON, dataId, enrichmentFields)!!
 
     assertThat(enrichedPayload.firstName).isEqualTo(prisonerRecord.firstName)
     assertThat(enrichedPayload.lastName).isEqualTo(prisonerRecord.lastName)
@@ -69,7 +70,7 @@ class PrisonerLookupServiceTest {
 
     every { prisonerApiService.findPrisonerById(dataId) }.returns(prisonerRecord)
 
-    val enrichedPayload = underTest.getEnrichedPayload(dataId, enrichmentFields)!!
+    val enrichedPayload = underTest.process(EventType.ENTERED_PRISON, dataId, enrichmentFields)!!
 
     assertThat(enrichedPayload.firstName).isEqualTo(prisonerRecord.firstName)
     assertThat(enrichedPayload.lastName).isNull()


### PR DESCRIPTION
Not sure how everyone feels about this as an approach, but it means adding an event handler is a little easier/doesn't need all the code changes.

If people like it, I'd want to rejig the tests
- each and every event type has exactly one handler
- splitting the aggregation from the event handlers themselves
- testing the aggregation