### PR TITLE
GPC-NONE: Clarify build.gradle labelling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,8 +90,8 @@ dependencies {
   // test containers
   testImplementation(platform("org.testcontainers:testcontainers-bom:1.17.6"))
   testImplementation("org.testcontainers:localstack")
-  // required for TestContainers https://github.com/testcontainers/testcontainers-java/issues/1442#issuecomment-694342883
   testImplementation("org.testcontainers:postgresql")
+  testImplementation("com.amazonaws:aws-java-sdk-core:1.12.407") // required for TestContainers https://github.com/testcontainers/testcontainers-java/issues/1442#issuecomment-694342883
 
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")
@@ -100,7 +100,6 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt:0.9.1")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.11")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone:2.35.0")
-  testImplementation("com.amazonaws:aws-java-sdk-core:1.12.407")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
   testImplementation("io.mockk:mockk:1.13.4")
   testImplementation("com.approvaltests:approvaltests:18.5.0")


### PR DESCRIPTION
Think this comment got detached during a rejig of dependencies, but this should make things clearer