### PR TITLE
GPC-117: Expose yaml openapi spec

### DIFF
--- a/src/main/kotlin/uk/gov/gdx/datashare/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/config/ResourceServerConfiguration.kt
@@ -16,10 +16,14 @@ class ResourceServerConfiguration {
       .csrf { it.disable() } // csrf not needed on a rest api
       .authorizeHttpRequests { requests ->
         requests.requestMatchers(
-          "/webjars/**", "/favicon.ico", "/csrf",
-          "/health/**", "/info", "/h2-console/**",
-          "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-          "/queue-admin/retry-all-dlqs", "/metrics/**",
+          "/favicon.ico",
+          "/health/**",
+          "/info",
+          "/v3/api-docs/**",
+          "/v3/api-docs.yaml",
+          "/swagger-ui/**",
+          "/swagger-ui.html",
+          "/metrics/**",
         ).permitAll().anyRequest().authenticated()
       }
       .oauth2ResourceServer { it.jwt() }


### PR DESCRIPTION
Needed for autogenerating sections of documentation: https://tdt-documentation.london.cloudapps.digital/write_docs/add_openapi_spec/#convert-an-openapi-specification-into-documentation