### PR TITLE
GPC-NONE: shuffle gauge configuration to persist value between calls

### DIFF
--- a/src/main/kotlin/uk/gov/gdx/datashare/services/ScheduledJobService.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/services/ScheduledJobService.kt
@@ -1,6 +1,5 @@
 package uk.gov.gdx.datashare.services
 
-import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import net.javacrumbs.shedlock.core.LockAssert
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
@@ -8,18 +7,21 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import uk.gov.gdx.datashare.repositories.EventDataRepository
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 @Service
 class ScheduledJobService(
   private val eventDataRepository: EventDataRepository,
-  private val meterRegistry: MeterRegistry,
+  meterRegistry: MeterRegistry,
 ) {
+  private val gauge = meterRegistry.gauge("UnconsumedEvents", AtomicInteger(0))
+
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
   @SchedulerLock(name = "countUnconsumedEvents", lockAtMostFor = "3m", lockAtLeastFor = "3m")
   fun countUnconsumedEvents() {
     LockAssert.assertLocked()
     EventDataService.log.debug("Looking for unconsumed events")
     val unconsumedEventsCount = eventDataRepository.countByDeletedAtIsNull()
-    Gauge.builder("UnconsumedEvents", unconsumedEventsCount, Int::toDouble).register(meterRegistry)
+    gauge!!.set(unconsumedEventsCount)
   }
 }


### PR DESCRIPTION
I think this is the problem with the UnconsumedEvents count, where when Micrometer is gathering metrics, there's no value available (the gauge itself doesn't really hold the value)