### PR TITLE
GPC-248: Enable Security Hub

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -130,8 +130,3 @@ module "consumer" {
   lev_api_url                 = "https://${module.lev_api.service_url}"
   schedule                    = "cron(0,30 9-18 ? * MON-FRI *)"
 }
-
-module "securityhub" {
-  source = "../modules/security_hub"
-  region = data.aws_region.current.name
-}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -130,3 +130,8 @@ module "consumer" {
   lev_api_url                 = "https://${module.lev_api.service_url}"
   schedule                    = "cron(0,30 9-18 ? * MON-FRI *)"
 }
+
+module "securityhub" {
+  source = "../modules/security_hub"
+  region = data.aws_region.current.name
+}

--- a/terraform/modules/security_hub/main.tf
+++ b/terraform/modules/security_hub/main.tf
@@ -1,0 +1,6 @@
+resource "aws_securityhub_account" "securityhub" {}
+
+resource "aws_securityhub_standards_subscription" "cis" {
+  depends_on    = [aws_securityhub_account.securityhub]
+  standards_arn = "arn:aws:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/1.4.0"
+}

--- a/terraform/modules/security_hub/variables.tf
+++ b/terraform/modules/security_hub/variables.tf
@@ -1,0 +1,1 @@
+variable "region" {}

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -50,6 +50,8 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+data "aws_region" "current" {}
+
 #tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
 module "vpc" {
   source = "git::https://github.com/Softwire/terraform-vpc-aws?ref=24b5808095f54de6909ae03c9b0ccc21a735c6c3"
@@ -67,7 +69,6 @@ module "vpc" {
     Environment = local.env
   }
 }
-
 
 module "grafana" {
   source = "./modules/grafana"
@@ -89,4 +90,9 @@ module "github_iam" {
   source      = "../modules/github_env_iam"
   environment = local.env
   account_id  = data.aws_caller_identity.current.account_id
+}
+
+module "securityhub" {
+  source = "../modules/security_hub"
+  region = data.aws_region.current.name
 }


### PR DESCRIPTION
We probably need to do something about getting notifications of outputs, and should discuss which standards we want to follow, but the CIS standard is a generally broad reaching and sensible baseline