### PR TITLE
GPC-NONE: Deny insecure transport to buckets

### DIFF
--- a/terraform/modules/data-share-service/s3.tf
+++ b/terraform/modules/data-share-service/s3.tf
@@ -66,3 +66,37 @@ resource "aws_s3_bucket_acl" "cloudfront_logs_bucket_grants" {
     }
   }
 }
+
+data "aws_iam_policy_document" "deny_insecure_transport" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.cloudfront_logs_bucket.arn,
+      "${aws_s3_bucket.cloudfront_logs_bucket.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "deny_insecure_transport" {
+  bucket = aws_s3_bucket.cloudfront_logs_bucket.id
+  policy = data.aws_iam_policy_document.deny_insecure_transport.json
+}

--- a/terraform/modules/grafana/cloudfront-logs.tf
+++ b/terraform/modules/grafana/cloudfront-logs.tf
@@ -64,3 +64,37 @@ resource "aws_s3_bucket_acl" "cloudfront_logs_bucket_grants" {
     }
   }
 }
+
+data "aws_iam_policy_document" "deny_insecure_transport" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.cloudfront_logs_bucket.arn,
+      "${aws_s3_bucket.cloudfront_logs_bucket.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "deny_insecure_transport" {
+  bucket = aws_s3_bucket.cloudfront_logs_bucket.id
+  policy = data.aws_iam_policy_document.deny_insecure_transport.json
+}

--- a/terraform/modules/s3/logs_bucket.tf
+++ b/terraform/modules/s3/logs_bucket.tf
@@ -33,3 +33,37 @@ resource "aws_s3_bucket_public_access_block" "log_bucket" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+data "aws_iam_policy_document" "log_bucket_deny_insecure_transport" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.log_bucket.arn,
+      "${aws_s3_bucket.log_bucket.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "log_bucket_deny_insecure_transport" {
+  bucket = aws_s3_bucket.log_bucket.id
+  policy = data.aws_iam_policy_document.deny_insecure_transport.json
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -67,3 +67,37 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+data "aws_iam_policy_document" "deny_insecure_transport" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.bucket.arn,
+      "${aws_s3_bucket.bucket.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "deny_insecure_transport" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.deny_insecure_transport.json
+}


### PR DESCRIPTION
To fix https://eu-west-2.console.aws.amazon.com/securityhub/home?region=eu-west-2#/standards/cis-aws-foundations-benchmark-1.4.0/S3.5