### PR TITLE
GPC-NONE: Ignore missing xray context

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,9 +112,3 @@ cognito:
 
 xray-tracing:
   enabled: true
-
-com:
-  amazonaws:
-    xray:
-      strategy:
-        contextMissingStrategy: IGNORE_ERROR

--- a/terraform/modules/data-share-service/ecs.tf
+++ b/terraform/modules/data-share-service/ecs.tf
@@ -66,6 +66,7 @@ resource "aws_ecs_task_definition" "gdx_data_share_poc" {
           "name" : "SPRINGDOC_SWAGGER_UI_OAUTH2_REDIRECT_URL",
           "value" : "${local.gdx_api_base_url}/swagger-ui/oauth2-redirect.html"
         },
+        { "name" : "AWS_XRAY_CONTEXT_MISSING", "value" : "IGNORE_ERROR" },
       ]
       secrets = [
         {


### PR DESCRIPTION
Looks like this can't be set using this style of config