### PR TITLE
GPC-NONE: Fix spring security deprecations

### DIFF
--- a/src/main/kotlin/uk/gov/gdx/datashare/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/gdx/datashare/config/ResourceServerConfiguration.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -65,6 +66,7 @@ class ResourceServerConfiguration {
       .build()
   }
 
+  @Order(Ordered.LOWEST_PRECEDENCE)
   @Bean
   fun apiFilterChain(http: HttpSecurity): SecurityFilterChain {
     return http

--- a/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/HealthCheckTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.integration.health
+package uk.gov.gdx.datashare.integration.actuator
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/InfoTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.integration.health
+package uk.gov.gdx.datashare.integration.actuator
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/PrometheusTest.kt
+++ b/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/PrometheusTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.actuator
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability
+import uk.gov.gdx.datashare.integration.SqsIntegrationTestBase
+
+@AutoConfigureObservability
+class PrometheusTest : SqsIntegrationTestBase() {
+  @Test
+  fun `Unauthenticated page is inaccessible`() {
+    webTestClient.get()
+      .uri("/prometheus")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `Authenticated page is accessible`() {
+    webTestClient
+      .get()
+      .uri("/prometheus")
+      .headers { it.setBasicAuth("prometheus", "prometheus") }
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+}


### PR DESCRIPTION
Please review carefully. Per https://docs.spring.io/spring-security/reference/servlet/configuration/java.html#_multiple_httpsecurity_instances (kotlin docs just seem to be wrong)