### PR TITLE
GPC-371: Use service domain

### DIFF
--- a/terraform/modules/data_share_service/cloudfront.tf
+++ b/terraform/modules/data_share_service/cloudfront.tf
@@ -1,5 +1,5 @@
 locals {
-  gdx_api_base_url = "https://${aws_cloudfront_distribution.gdx_data_share_poc.domain_name}"
+  gdx_api_base_url = "https://${var.hosted_zone_name}"
 }
 
 #tfsec:ignore:aws-cloudfront-use-secure-tls-policy


### PR DESCRIPTION
This change has the following effects:

- Change cognito user pool admin client permitted callback url to the `service.gov.uk` version
- Change `SPRINGDOC_SWAGGER_UI_OAUTH2_REDIRECT_URL` env var to `service.gov.uk` version
- Change len lambdas to point at `service.gov.uk` domain
- Change gro lambdas to point as `service.gov.uk` domain