### PR TITLE
Make platform name consistent

### DIFF
--- a/techdocs/source/index.html.md.erb
+++ b/techdocs/source/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: About the DI Life Event Platform
+title: About the DI Life Events Platform
 weight: 10
 ---
 
-# About the DI Life Event Platform
+# About the DI Life Events Platform
 
 
 
@@ -11,12 +11,12 @@ weight: 10
 
 <%= warning_text("This is not a live service. All data is synthetic test data.") %>
 
-The DI (Digital Identity) Life Event Platform is intended to facilitate cross government data sharing of
+The DI (Digital Identity) Life Events Platform is intended to facilitate cross government data sharing of
 citizen life events. All transfer of information would be governed by data sharing agreements. The aim of this platform is
 not to give departments access to more information, but to make it easier to send and receive data which they are
 entitled to have.
 
-**The Life Event Platform is not a live service.** The platform currently provides a feed of mock death events.
+**The Life Events Platform is not a live service.** The platform currently provides a feed of mock death events.
 
 ## Onboarding
 


### PR DESCRIPTION
Name in header banner had an ess, so let's say 'events' everywhere